### PR TITLE
Add several string methods to ULoc

### DIFF
--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -22,7 +22,11 @@ use {std::env, std::fs::File, std::io::Write, std::path::Path, std::process::Com
 
 // Captures the stdout of the command or panics.
 fn stdout(c: &mut Command) -> String {
-    let result = c.output().expect("could not execute");
+    let result = c
+        .output()
+        .unwrap_or_else(|e| {
+            panic!("Error while executing command [{:?}]:\n{:?}", c, e);
+        });
     let result = String::from_utf8(result.stdout).expect("could not parse as utf8");
     result.trim().to_string()
 }
@@ -260,6 +264,7 @@ macro_rules! versioned_function {
 }
 
 fn main() {
+    std::env::set_var("RUST_BACKTRACE", "full");
     println!("rustfmt: {}", rustfmt_version());
     println!("icu-config: {}", icu_config_version());
     println!("icu-config-cpp-flags: {}", icu_cpp_flags());

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -48,13 +48,70 @@ impl TryFrom<&ffi::CStr> for ULoc {
         ULoc {
             repr: String::from(repr),
         }
-        .canonicalize()
+            .canonicalize()
     }
 }
 
 impl ULoc {
+    /// Implements `uloc_getLanguage`.
+    pub fn language(&self) -> Result<String, common::Error> {
+        self.call_buffered_string_method(versioned_function!(uloc_getLanguage))
+    }
+
+    /// Implements `uloc_getScript`.
+    pub fn script(&self) -> Result<String, common::Error> {
+        self.call_buffered_string_method(versioned_function!(uloc_getScript))
+    }
+
+    /// Implements `uloc_getCountry`.
+    pub fn country(&self) -> Result<String, common::Error> {
+        self.call_buffered_string_method(versioned_function!(uloc_getCountry))
+    }
+
+    /// Implements `uloc_getVariant`.
+    pub fn variant(&self) -> Result<String, common::Error> {
+        self.call_buffered_string_method(versioned_function!(uloc_getVariant))
+    }
+
     /// Implements `uloc_canonicalize` from ICU4C.
     pub fn canonicalize(&self) -> Result<ULoc, common::Error> {
+        self.call_buffered_string_method(versioned_function!(uloc_canonicalize))
+            .map(|repr| ULoc { repr })
+    }
+
+    /// Implements `uloc_addLikelySubtags` from ICU4C.
+    pub fn add_likely_subtags(&self) -> Result<ULoc, common::Error> {
+        self.call_buffered_string_method(versioned_function!(uloc_addLikelySubtags))
+            .map(|repr| ULoc { repr })
+    }
+
+    /// Implements `uloc_minimizeSubtags` from ICU4C.
+    pub fn minimize_subtags(&self) -> Result<ULoc, common::Error> {
+        self.call_buffered_string_method(versioned_function!(uloc_minimizeSubtags))
+            .map(|repr| ULoc { repr })
+    }
+
+    /// Returns the current label of this locale.
+    pub fn label(&self) -> &str {
+        &self.repr
+    }
+
+    /// Returns the current locale name as a C string.
+    pub fn as_c_str(&self) -> ffi::CString {
+        ffi::CString::new(self.repr.clone()).expect("ULoc contained interior NUL bytes")
+    }
+
+    /// Call a `uloc_*` method with a particular signature (that clones and modifies the internal
+    /// representation of the locale ID and requires a resizable buffer).
+    fn call_buffered_string_method(
+        &self,
+        uloc_method: unsafe extern "C" fn(
+            *const raw::c_char,
+            *mut raw::c_char,
+            i32,
+            *mut UErrorCode,
+        ) -> i32,
+    ) -> Result<String, common::Error> {
         let mut status = common::Error::OK_CODE;
         let repr = ffi::CString::new(self.repr.clone())
             .map_err(|_| common::Error::string_with_interior_nul())?;
@@ -64,7 +121,7 @@ impl ULoc {
         // Requires that repr is a valid pointer
         let full_len = unsafe {
             assert!(common::Error::is_ok(status));
-            versioned_function!(uloc_canonicalize)(
+            uloc_method(
                 repr.as_ptr(),
                 buf.as_mut_ptr() as *mut raw::c_char,
                 CAP as i32,
@@ -78,7 +135,7 @@ impl ULoc {
             // the output buffer size.
             unsafe {
                 assert!(common::Error::is_ok(status));
-                versioned_function!(uloc_canonicalize)(
+                uloc_method(
                     repr.as_ptr(),
                     buf.as_mut_ptr() as *mut raw::c_char,
                     full_len as i32,
@@ -89,21 +146,7 @@ impl ULoc {
         }
         // Adjust the size of the buffer here.
         buf.resize(full_len, 0);
-        let s = String::from_utf8(buf);
-        match s {
-            Ok(repr) => Ok(ULoc { repr }),
-            Err(_) => Err(common::Error::string_with_interior_nul()),
-        }
-    }
-
-    /// Returns the current label of this locale.
-    pub fn label(&self) -> &str {
-        &self.repr
-    }
-
-    /// Returns the current locale name as a C string.
-    pub fn as_c_str(&self) -> ffi::CString {
-        ffi::CString::new(self.repr.clone()).expect("ULoc contained interior NUL bytes")
+        String::from_utf8(buf).map_err(|_| common::Error::string_with_interior_nul())
     }
 }
 
@@ -116,7 +159,7 @@ pub fn get_default() -> ULoc {
     crate::ULoc::try_from(uloc_cstr).expect("could not convert default locale to ULoc")
 }
 
-/// Sets the current defaultl system locale.
+/// Sets the current default system locale.
 ///
 /// Implements `uloc_setDefault` from ICU4C.
 pub fn set_default(loc: &ULoc) -> Result<(), common::Error> {
@@ -132,6 +175,34 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_language() {
+        let loc = ULoc::try_from("es-CO").expect("get es_CO locale");
+        let language = loc.language().expect("should get language");
+        assert_eq!(&language, "es");
+    }
+
+    #[test]
+    fn test_script() {
+        let loc = ULoc::try_from("sr-Cyrl").expect("get sr_Cyrl locale");
+        let script = loc.script().expect("should get script");
+        assert_eq!(&script, "Cyrl");
+    }
+
+    #[test]
+    fn test_country() {
+        let loc = ULoc::try_from("es-CO").expect("get es_CO locale");
+        let country = loc.country().expect("should get country");
+        assert_eq!(&country, "CO");
+    }
+
+    #[test]
+    fn test_variant() {
+        let loc = ULoc::try_from("zh-Latn-pinyin").expect("get zh_Latn_pinyin locale");
+        let variant = loc.variant().expect("should get variant");
+        assert_eq!(&variant, "PINYIN");
+    }
+
+    #[test]
     fn test_default_locale() {
         let loc = ULoc::try_from("fr-fr").expect("get fr_FR locale");
         set_default(&loc).expect("successful set of locale");
@@ -140,5 +211,21 @@ mod tests {
         let loc = ULoc::try_from("en-us").expect("get en_US locale");
         set_default(&loc).expect("successful set of locale");
         assert_eq!(get_default().label(), loc.label());
+    }
+
+    #[test]
+    fn test_add_likely_subtags() {
+        let loc = ULoc::try_from("en-US").expect("get en_US locale");
+        let with_likely_subtags = loc.add_likely_subtags().expect("should add likely subtags");
+        let expected = ULoc::try_from("en_Latn_US").expect("get en_Latn_US locale");
+        assert_eq!(with_likely_subtags.label(), expected.label());
+    }
+
+    #[test]
+    fn test_minimize_subtags() {
+        let loc = ULoc::try_from("sr_Cyrl_RS").expect("get sr_Cyrl_RS locale");
+        let minimized_subtags = loc.minimize_subtags().expect("should minimize subtags");
+        let expected = ULoc::try_from("sr").expect("get sr locale");
+        assert_eq!(minimized_subtags.label(), expected.label());
     }
 }


### PR DESCRIPTION
- `language()`, `script()`, `country()`, `variant()`
- `add_likely_subtags()`, `minimize_subtags()`

Also improve error message in `build.rs`.