### PR TITLE
Migrate from `failure` to `thiserror`

### DIFF
--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -16,5 +16,5 @@ Commonly used types.
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
-failure = "0.1.5"
+thiserror = "1.0.9"
 rust_icu_sys = { path = "../rust_icu_sys" }

--- a/rust_icu_common/src/lib.rs
+++ b/rust_icu_common/src/lib.rs
@@ -16,13 +16,13 @@
 //!
 //! At the moment, this crate contains the declaration of various errors
 
-use {rust_icu_sys as sys, std::ffi, std::os, failure::Fail};
+use {rust_icu_sys as sys, std::ffi, std::os, thiserror::Error};
 
 /// Represents a Unicode error, resulting from operations of low-level ICU libraries.
 ///
 /// This is modeled after absl::Status in the Abseil library, which provides ways
 /// for users to avoid dealing with all the numerous error codes directly.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// The error originating in the underlying sys library.
     ///
@@ -30,12 +30,12 @@ pub enum Error {
     /// error), because it makes it unnecessary for users to deal with error codes directly.  It
     /// does make for a bit weird API, so we may turn it around a bit.  Ideally, it should not be
     /// possible to have an Error that isn't really an error.
-    #[fail(display = "ICU error code: {}", _0)]
+    #[error("ICU error code: {}", _0)]
     Sys(sys::UErrorCode),
 
     /// Errors originating from the wrapper code.  For example when pre-converting input into
     /// UTF8 for input that happens to be malformed.
-    #[fail(display = "wrapper error: {}", _0)]
+    #[error("wrapper error: {}", _0)]
     Wrapper(&'static str),
 }
 


### PR DESCRIPTION
Use `thiserror` crate, which provides derivations for `std::Error::Error`.