### PR TITLE
Prepares rust_icu for publication to `crates.io`.

### DIFF
--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -17,4 +17,4 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 thiserror = "1.0.9"
-rust_icu_sys = { path = "../rust_icu_sys" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }

--- a/rust_icu_common/README.md
+++ b/rust_icu_common/README.md
@@ -1,0 +1,3 @@
+# rust-icu: low-level rust language bindings for the ICU library
+
+Please see [the top-level README.md file](https://github.com/google/rust_icu/blob/master/README.md).

--- a/rust_icu_sys/README.md
+++ b/rust_icu_sys/README.md
@@ -1,0 +1,3 @@
+# rust-icu: low-level rust language bindings for the ICU library
+
+Please see [the top-level README.md file](https://github.com/google/rust_icu/blob/master/README.md).

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition = "2018"
-name = "rust_icu_ucal"
-version = "0.0.0"
 authors = ["Google Inc."]
+edition = "2018"
 license = "Apache-2.0"
+name = "rust_icu_ucal"
 readme = "README.md"
-repository = "https://github.com/google/rust_icu/rust_icu_ucal"
+repository = "https://github.com/google/rust_icu"
+version = "0.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,7 +18,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common" }
-rust_icu_sys = { path = "../rust_icu_sys" }
-rust_icu_uenum = { path = "../rust_icu_uenum" }
-rust_icu_ustring = { path = "../rust_icu_ustring" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.0" }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.0" }

--- a/rust_icu_ucal/README.md
+++ b/rust_icu_ucal/README.md
@@ -1,0 +1,3 @@
+# rust-icu: low-level rust language bindings for the ICU library
+
+Please see [the top-level README.md file](https://github.com/google/rust_icu/blob/master/README.md).

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition = "2018"
-name = "rust_icu_udat"
-version = "0.0.0"
 authors = ["Google Inc."]
+edition = "2018"
 license = "Apache-2.0"
+name = "rust_icu_udat"
 readme = "README.md"
-repository = "https://github.com/google/rust_icu/rust_icu_udat"
+repository = "https://github.com/google/rust_icu"
+version = "0.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common" }
-rust_icu_sys = { path = "../rust_icu_sys" }
-rust_icu_ucal = { path = "../rust_icu_ucal" }
-rust_icu_uenum = { path = "../rust_icu_uenum" }
-rust_icu_uloc = { path = "../rust_icu_uloc" }
-rust_icu_ustring = { path = "../rust_icu_ustring" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.0.0" }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.0" }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.0.0" }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.0" }
 

--- a/rust_icu_udat/README.md
+++ b/rust_icu_udat/README.md
@@ -1,0 +1,3 @@
+# rust-icu: low-level rust language bindings for the ICU library
+
+Please see [the top-level README.md file](https://github.com/google/rust_icu/blob/master/README.md).

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition = "2018"
-name = "rust_icu_udata"
-version = "0.0.0"
 authors = ["Google Inc."]
+edition = "2018"
 license = "Apache-2.0"
+name = "rust_icu_udata"
 readme = "README.md"
-repository = "https://github.com/google/rust_icu/rust_icu_udata"
+repository = "https://github.com/google/rust_icu"
+version = "0.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,6 +18,6 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common" }
-rust_icu_sys = { path = "../rust_icu_sys" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
 

--- a/rust_icu_udata/README.md
+++ b/rust_icu_udata/README.md
@@ -1,0 +1,3 @@
+# rust-icu: low-level rust language bindings for the ICU library
+
+Please see [the top-level README.md file](https://github.com/google/rust_icu/blob/master/README.md).

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-edition = "2018"
-name = "rust_icu_uenum"
-version = "0.0.0"
 authors = ["Google Inc."]
+edition = "2018"
 license = "Apache-2.0"
+name = "rust_icu_uenum"
 readme = "README.md"
-repository = "https://github.com/google/rust_icu/rust_icu_uenum"
+repository = "https://github.com/google/rust_icu"
+version = "0.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
 
-uenum.h
+Implements `uenum.h` from the ICU4C API.
 """
 
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_sys = { path = "../rust_icu_sys" }
-rust_icu_common = { path = "../rust_icu_common" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }

--- a/rust_icu_uenum/README.md
+++ b/rust_icu_uenum/README.md
@@ -1,0 +1,3 @@
+# rust-icu: low-level rust language bindings for the ICU library
+
+Please see [the top-level README.md file](https://github.com/google/rust_icu/blob/master/README.md).

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition = "2018"
-name = "rust_icu_uloc"
-version = "0.0.0"
 authors = ["Google Inc."]
+edition = "2018"
 license = "Apache-2.0"
+name = "rust_icu_uloc"
 readme = "README.md"
-repository = "https://github.com/google/rust_icu/rust_icu_uloc"
+repository = "https://github.com/google/rust_icu"
+version = "0.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,7 +18,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common" }
-rust_icu_sys = { path = "../rust_icu_sys" }
-rust_icu_uenum = { path = "../rust_icu_uenum" }
-rust_icu_ustring = { path = "../rust_icu_ustring" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.0" }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.0" }

--- a/rust_icu_uloc/README.md
+++ b/rust_icu_uloc/README.md
@@ -1,0 +1,3 @@
+# rust-icu: low-level rust language bindings for the ICU library
+
+Please see [the top-level README.md file](https://github.com/google/rust_icu/blob/master/README.md).

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition = "2018"
-name = "rust_icu_ustring"
-version = "0.0.0"
 authors = ["Google Inc."]
+edition = "2018"
 license = "Apache-2.0"
+name = "rust_icu_ustring"
 readme = "README.md"
-repository = "https://github.com/google/rust_icu/rust_icu_ustring"
+repository = "https://github.com/google/rust_icu"
+version = "0.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,5 +18,5 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common" }
-rust_icu_sys = { path = "../rust_icu_sys" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }

--- a/rust_icu_ustring/README.md
+++ b/rust_icu_ustring/README.md
@@ -1,0 +1,3 @@
+# rust-icu: low-level rust language bindings for the ICU library
+
+Please see [the top-level README.md file](https://github.com/google/rust_icu/blob/master/README.md).

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/google/rust_icu/rust_icu_utext"
+repository = "https://github.com/google/rust_icu"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,5 +17,5 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common" }
-rust_icu_sys = { path = "../rust_icu_sys" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }

--- a/rust_icu_utext/README.md
+++ b/rust_icu_utext/README.md
@@ -1,0 +1,3 @@
+# rust-icu: low-level rust language bindings for the ICU library
+
+Please see [the top-level README.md file](https://github.com/google/rust_icu/blob/master/README.md).


### PR DESCRIPTION
Contains the changes that were required to make publication work.

- Modifies all `Cargo.toml` files into the form suitable for
  publication.
- Adds a README.md file for rust_icu_sys
- Adds a README.md file for rust_icu_common
- Adds a README.md file for rust_icu_uenum
- Adds a README.md file for rust_icu_ustring
- Adds a README.md file for rust_icu_ucal
- Adds a README.md file for rust_icu_udata
- Adds a README.md file for rust_icu_udat and rust_icu_uloc
- Adds a README.md file for rust_icu_utext

Fixes #15