### PR TITLE
Adds an option to skip icu-config run.

### DIFF
--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,4 +17,4 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 thiserror = "1.0.9"
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -29,7 +29,7 @@ anyhow = "1.0"
 doctest = false
 
 [features]
-default = ["bindgen", "renaming"]
+default = ["bindgen", "renaming", "icu_config"]
 
 # If set, cargo will run 'bindgen' to generate bindings based on the installed
 # ICU library.  The program `icu-config` must be in $PATH for this to work, and
@@ -41,4 +41,9 @@ bindgen = []
 # specific ICU version is required.  See
 # http://userguide.icu-project.org/design for a discussion of renaming.
 renaming = []
+
+# If set, the binary icu-config will be used to configure the library.  Turn
+# this feature off if you do not want `build.rs` to try to autodetect the build
+# environment.
+icu_config = []
 

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -332,6 +332,9 @@ macro_rules! versioned_function {{
 }
 
 fn main() -> Result<()> {
+    if let None = env::var_os("CARGO_FEATURE_ICU_CONFIG") {
+        return Ok(());
+    }
     std::env::set_var("RUST_BACKTRACE", "full");
     println!("rustfmt: {}", rustfmt_version()?);
     println!("icu-config: {}", ICUConfig::new().version()?);

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.0"
+version = "0.0.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,7 +18,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.0" }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.0" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.1" }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.1" }

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.0"
+version = "0.0.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.0.0" }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.0" }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.0.0" }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.0" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.0.1" }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.1" }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.0.1" }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.1" }
 

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.0"
+version = "0.0.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,6 +18,6 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
 

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.0"
+version = "0.0.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,5 +17,5 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uloc"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.0"
+version = "0.0.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,7 +18,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.0" }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.0" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.1" }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.1" }

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.0"
+version = "0.0.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,5 +18,5 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,5 +17,5 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.0" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.0" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }


### PR DESCRIPTION
Some environments do not need the `build.rs` smarts.  Allow the users
to skip using build.rs in such environments.

Fixes: #20