### PR TITLE
Reexports features throughout.

### DIFF
--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,4 +17,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 thiserror = "1.0.9"
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.2" }
+
+# See the feature description in ../rust_icu_sys/Cargo.toml for details.
+[features]
+default = ["bindgen", "renaming", "icu_config"]
+bindgen = ["rust_icu_sys/bindgen"]
+renaming = ["rust_icu_sys/renaming"]
+icu_config = ["rust_icu_sys/renaming"]
+

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.1"
+version = "0.0.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,7 +18,30 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.1" }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.1" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.2" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.2" }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.2" }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.2" }
+
+# See the feature description in ../rust_icu_sys/Cargo.toml for details.
+[features]
+default = ["bindgen", "renaming", "icu_config"]
+
+bindgen = [
+  "rust_icu_common/bindgen",
+  "rust_icu_sys/bindgen",
+  "rust_icu_uenum/bindgen",
+  "rust_icu_ustring/bindgen",
+]
+renaming = [
+  "rust_icu_common/renaming",
+  "rust_icu_sys/renaming",
+  "rust_icu_uenum/renaming",
+  "rust_icu_ustring/renaming",
+]
+icu_config = [
+  "rust_icu_common/icu_config",
+  "rust_icu_sys/icu_config",
+  "rust_icu_uenum/icu_config",
+  "rust_icu_ustring/icu_config",
+]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.1"
+version = "0.0.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,38 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.0.1" }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.1" }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.0.1" }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.1" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.2" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.2" }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.0.2" }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.2" }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.0.2" }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.2" }
 
+# See the feature description in ../rust_icu_sys/Cargo.toml for details.
+[features]
+default = ["bindgen", "renaming", "icu_config"]
+
+bindgen = [
+  "rust_icu_common/bindgen",
+  "rust_icu_sys/bindgen",
+  "rust_icu_ucal/bindgen",
+  "rust_icu_uenum/bindgen",
+  "rust_icu_uloc/bindgen",
+  "rust_icu_ustring/bindgen",
+]
+renaming = [
+  "rust_icu_common/renaming",
+  "rust_icu_sys/renaming",
+  "rust_icu_ucal/renaming",
+  "rust_icu_uenum/renaming",
+  "rust_icu_uloc/renaming",
+  "rust_icu_ustring/renaming",
+]
+icu_config = [
+  "rust_icu_common/icu_config",
+  "rust_icu_sys/icu_config",
+  "rust_icu_ucal/icu_config",
+  "rust_icu_uenum/icu_config",
+  "rust_icu_uloc/icu_config",
+  "rust_icu_ustring/icu_config",
+]

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.1"
+version = "0.0.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,6 +18,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.2" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.2" }
+
+# See the feature description in ../rust_icu_sys/Cargo.toml for details.
+[features]
+default = ["bindgen", "renaming", "icu_config"]
+
+bindgen = ["rust_icu_sys/bindgen", "rust_icu_common/bindgen"]
+renaming = ["rust_icu_sys/renaming", "rust_icu_common/renaming"]
+icu_config = ["rust_icu_sys/icu_config", "rust_icu_common/icu_config"]
 

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.1"
+version = "0.0.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,5 +17,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.2" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.2" }
+
+# See the feature description in ../rust_icu_sys/Cargo.toml for details.
+[features]
+default = ["bindgen", "renaming", "icu_config"]
+
+bindgen = ["rust_icu_sys/bindgen", "rust_icu_common/bindgen"]
+renaming = ["rust_icu_sys/renaming", "rust_icu_common/renaming"]
+icu_config = ["rust_icu_sys/icu_config", "rust_icu_common/icu_config"]
+

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uloc"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.1"
+version = "0.0.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,7 +18,30 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.1" }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.1" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.2" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.2" }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.2" }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.2" }
+
+# See the feature description in ../rust_icu_sys/Cargo.toml for details.
+[features]
+default = ["bindgen", "renaming", "icu_config"]
+
+bindgen = [
+  "rust_icu_common/bindgen",
+  "rust_icu_sys/bindgen",
+  "rust_icu_uenum/bindgen",
+  "rust_icu_ustring/bindgen",
+]
+renaming = [
+  "rust_icu_common/renaming",
+  "rust_icu_sys/renaming",
+  "rust_icu_uenum/renaming",
+  "rust_icu_ustring/renaming",
+]
+icu_config = [
+  "rust_icu_common/icu_config",
+  "rust_icu_sys/icu_config",
+  "rust_icu_uenum/icu_config",
+  "rust_icu_ustring/icu_config",
+]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.1"
+version = "0.0.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,5 +18,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.8"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.2" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.2" }
+
+# See the feature description in ../rust_icu_sys/Cargo.toml for details.
+[features]
+default = ["bindgen", "renaming", "icu_config"]
+
+bindgen = ["rust_icu_sys/bindgen", "rust_icu_common/bindgen"]
+renaming = ["rust_icu_sys/renaming", "rust_icu_common/renaming"]
+icu_config = ["rust_icu_sys/icu_config", "rust_icu_common/icu_config"]
+

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,5 +17,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.1" }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.1" }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.2" }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.2" }
+
+# See the feature description in ../rust_icu_sys/Cargo.toml for details.
+[features]
+default = ["bindgen", "renaming", "icu_config"]
+
+bindgen = ["rust_icu_sys/bindgen", "rust_icu_common/bindgen"]
+renaming = ["rust_icu_sys/renaming", "rust_icu_common/renaming"]
+icu_config = ["rust_icu_sys/icu_config", "rust_icu_common/icu_config"]
+


### PR DESCRIPTION
This looks as if it may be required for our ability to turn certain
features *off* when compiling for targets that do not require special
settings.

I'm not super-convinced that this is the case, but the only way to
test the theory is to try it out.