### PR TITLE
Corrects the repository URLs where wrong.

### DIFF
--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.2"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/google/rust_icu/rust_icu_common"
+repository = "https://github.com/google/rust_icu"
 
 description = """
 Native bindings to the ICU4C library from Unicode.

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
 build = "build.rs"
-repository = "https://github.com/google/rust_icu/rust_icu_sys"
+repository = "https://github.com/google/rust_icu"
 edition = "2018"
 
 links = "icuuc"


### PR DESCRIPTION
Two repository paths in `Cargo.toml` files incorrectly referred
to subdirectories, instead of top-level repository URLs.

Fixes: #25