### PR TITLE
Add wrapper for `uloc_acceptLanguage`

### DIFF
--- a/rust_icu_common/src/lib.rs
+++ b/rust_icu_common/src/lib.rs
@@ -16,7 +16,11 @@
 //!
 //! At the moment, this crate contains the declaration of various errors
 
-use {rust_icu_sys as sys, std::ffi, std::os, thiserror::Error};
+use {
+    rust_icu_sys as sys,
+    std::{borrow::Cow, ffi, os},
+    thiserror::Error,
+};
 
 /// Represents a Unicode error, resulting from operations of low-level ICU libraries.
 ///
@@ -36,7 +40,7 @@ pub enum Error {
     /// Errors originating from the wrapper code.  For example when pre-converting input into
     /// UTF8 for input that happens to be malformed.
     #[error("wrapper error: {}", _0)]
-    Wrapper(&'static str),
+    Wrapper(Cow<'static, str>),
 }
 
 impl Error {
@@ -80,7 +84,7 @@ impl Error {
     /// An error occurring when a string with interior NUL byte is converted to C string.
     // TODO(fmil): rework common::Error to be more rustful.
     pub fn string_with_interior_nul() -> Self {
-        Error::Wrapper("attempted to convert a string with interior NUL byte")
+        Error::wrapper("attempted to convert a string with interior NUL byte")
     }
 
     /// Returns true if this error has the supplied `code`.
@@ -122,6 +126,10 @@ impl Error {
             Error::Sys(c) => *c < sys::UErrorCode::U_ZERO_ERROR,
             _ => false,
         }
+    }
+
+    pub fn wrapper(msg: impl Into<Cow<'static, str>>) -> Self {
+        Self::Wrapper(msg.into())
     }
 }
 

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -205,6 +205,7 @@ fn commaify(s: &Vec<&str>) -> String {
 
 fn run_bindgen(header_file: &str, out_dir_path: &Path) -> Result<()> {
     let whitelist_types_regexes = commaify(&vec![
+        "UAcceptResult",
         "UBool",
         "UCalendar.*",
         "UChar.*",

--- a/rust_icu_sys/src/lib.rs
+++ b/rust_icu_sys/src/lib.rs
@@ -12,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #![doc(test(ignore))]
 #![allow(
     dead_code,
@@ -22,18 +21,18 @@
     unused_imports
 )]
 
-#[cfg(features="bindgen")]
+#[cfg(features = "bindgen")]
 include!(concat!(env!("OUT_DIR"), "/macros.rs"));
-#[cfg(all(features="bindgen",features="icu_config",not(features="icu_version_in_env")))]
+#[cfg(all(features = "bindgen",features="icu_config",not(features="icu_version_in_env")))]
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 // Linker trickery to ensure that we link against correct libraries.
-#[cfg(all(features="bindgen",features="icu_config",not(features="icu_version_in_env")))]
+#[cfg(all(features = "bindgen",features="icu_config",not(features="icu_version_in_env")))]
 include!(concat!(env!("OUT_DIR"), "/link.rs"));
 
-#[cfg(not(features="bindgen"))]
+#[cfg(not(features = "bindgen"))]
 include!("../bindgen/macros.rs");
 
-#[cfg(all(not(features="bindgen"),not(features="icu_version_in_env"),not(features="icu_config")))]
+#[cfg(all(not(features = "bindgen"),not(features="icu_version_in_env"),not(features="icu_config")))]
 include!("../bindgen/lib.rs");
 
 #[cfg(all(not(features="bindgen"),features="icu_version_in_env",not(features="icu_config")))]

--- a/rust_icu_udata/src/lib.rs
+++ b/rust_icu_udata/src/lib.rs
@@ -59,4 +59,3 @@ impl TryFrom<Vec<u8>> for crate::UDataMemory {
         Ok(UDataMemory { buf })
     }
 }
-

--- a/rust_icu_uenum/src/lib.rs
+++ b/rust_icu_uenum/src/lib.rs
@@ -34,6 +34,13 @@ pub struct Enumeration {
     rep: *mut sys::UEnumeration,
 }
 
+impl Enumeration {
+    /// Internal representation, for ICU4C methods that require it.
+    pub fn repr(&mut self) -> *mut sys::UEnumeration {
+        self.rep
+    }
+}
+
 /// Creates an enumeration iterator from a vector of UTF-8 strings.
 impl TryFrom<&[&str]> for Enumeration {
     type Error = common::Error;

--- a/rust_icu_ustring/src/lib.rs
+++ b/rust_icu_ustring/src/lib.rs
@@ -146,7 +146,7 @@ impl TryFrom<&UChar> for String {
         common::Error::ok_or_warning(status)?;
         let s = String::from_utf8(buf);
         match s {
-            Err(_) => Err(common::Error::Wrapper("could not conver to utf8")),
+            Err(_) => Err(common::Error::wrapper("could not convert to utf8")),
             Ok(x) => {
                 trace!("result UChar*->utf8: {:?}", x);
                 Ok(x)

--- a/rust_icu_utext/src/lib.rs
+++ b/rust_icu_utext/src/lib.rs
@@ -66,7 +66,7 @@ impl TryFrom<&str> for Text {
 impl Text {
     /// Constructs the Text from raw byte contents.
     ///
-    /// The expectation is that the buffer and length are valid and compatible.  That is, 
+    /// The expectation is that the buffer and length are valid and compatible.  That is,
     /// that buffer is a valid pointer, that it points to an allocated buffer and that the length
     /// of the allocated buffer is exactly `len`.
     unsafe fn from_raw_bytes(buffer: *const raw::c_char, len: i64) -> Result<Self, common::Error> {


### PR DESCRIPTION
Note that due to a [bug in ICU4C](https://unicode-org.atlassian.net/projects/ICU/issues/ICU-20931), this only accepts exact matches.