### PR TITLE
Adds docker-based build and test processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+TOP_DIR := ${PWD}
+DOCKER_REPO ?= filipfilmar
+
+UID := $(shell id -u)
+GID := $(shell id -g)
+INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
+ifeq (${INTERACTIVE},1)
+  TTY := --tty --interactive
+else
+  TTY :=
+endif
+
+.PHONY: test
+test:
+	env LD_LIBRARY_PATH="$(shell icu-config --libdir)" cargo test
+
+# Run a test inside a Docker container.
+.PHONY: docker-test
+docker-test:
+	docker run ${TTY} \
+			--volume=${TOP_DIR}:/src/rust_icu \
+			rust_icu_test
+
+# Builds and pushes the build environment containers.  You would not normally
+# need to do this.
+.PHONY: buildenv
+buildenv:
+	make -C build DOCKER_REPO=${DOCKER_REPO} all

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ International Components for Unicode (ICU) library for C (a.k.a. ICU4C).
 See: http://icu-project.org for details about the ICU library.  The library
 source can be viewed on Github at https://github.com/unicode-org/icu.
 
-NOTE: This is not an officially supported Google product.
+> This is not an officially supported Google product.
 
 ## Why wrap ICU (vs. doing anything else)?
 
@@ -75,18 +75,18 @@ headers of columns 2 and onwards are features set combos.  The coverage
 reflects the feature set and version points that we needed up to this point.
 The version semver in each cell denotes the version point that was tested.
 
-| ICU version | `default` | `renaming` | `renaming`, `icu_version_in_env`| 
-| ----------- | ------------------- | ---------------------- | ----- | 
+| ICU version | `default` | `renaming` | `renaming`, `icu_version_in_env`|
+| ----------- | ------------------- | ---------------------- | ----- |
 | 63.x        | ???                   | ???                      | ??? |
 | 64.2        | 0.0.{3,4}             | ???                      | ??? |
 | 65.1        | 0.0.4                 | 0.0.4                    | 0.0.4 |
 | 66.0.1      | 0.0.4                 | ???                      | ??? |
 
-NOTE: API versions that differ in the minor version number only should be
-compatible; but since it is time consuming to test all versions and relatively
-easy to keep only the last major edition of the library around, we keep only
-one minor version per library in the table, until need arises to do something
-else.
+> API versions that differ in the minor version number only should be
+> compatible; but since it is time consuming to test all versions and
+> relatively easy to keep only the last major edition of the library around, we
+> keep only one minor version per library in the table, until need arises to do
+> something else.
 
 # Features
 
@@ -127,7 +127,8 @@ confusing compilation end result.
 
 * `rustup`
 
-  Install from https://rustup.rs.  Used to set toolchain defaults.
+  Install from https://rustup.rs.  Used to set toolchain defaults.  This will
+  install `cargo` as well.
 
 * `rust` nightly toolchain
 
@@ -163,6 +164,18 @@ confusing compilation end result.
 
 ## Optional
 
+* GNU Make, if you want to use the make-based build and test.
+
+   Installing GNU Make is beyond the scope of this file. Please refer to your
+   OS instructions for installation.
+
+* `docker`, if you decide to use docker-based build and test.
+
+   Installing `docker` is beyond the scope of this file, please see the [docker
+   installation instructions](https://docs.docker.com/install/) for details.
+   As installing `docker` is intrusive to the host machine, your company may
+   have internal documentation on how to install `docker` properly.
+
 * `icu-config` utility, if `icu_config` feature is used.
 
   You need to install the ICU library on your system, such that the binary
@@ -182,6 +195,12 @@ confusing compilation end result.
 
 # Testing
 
+There are a few options to run the test for `rust_icu`.
+
+## Cargo
+
+Building and testing using `cargo` is the 
+
 The following tests should all build and pass.  Note that because the libraries
 needed are in a custom location, we need to set `LD_LIBRARY_PATH` when running
 the tests.
@@ -190,7 +209,31 @@ the tests.
 env LD_LIBRARY_PATH="$(icu-config --libdir)" cargo test
 ```
 
-NOTE: This will get better. See: https://github.com/google/rust_icu/issues/9
+## GNU Make
+
+The easiest way is to use GNU Make and run:
+
+```
+make test
+```
+
+You may want to use this method if you are working on `rust_icu`, have your
+development environment all set up and would like a shorthand to run the tests.
+
+## Docker-based
+
+> See [optional dependencies section](#optional) above.
+
+To run a hermetic build and test of the `rust_icu` source code, issue the
+following command:
+
+```bash
+make docker-test
+```
+
+This will run docker-based build and test of the source code on your local
+machine.  This is a good way to test that your code works with a specific
+reference version of ICU.
 
 # Prior art
 
@@ -311,7 +354,7 @@ that is listed in your `$PATH` you should be all set to compile `rust_icu`.
 
 If you change the configuration of the ICU library with an intention to rebuild
 the library from source you should probably add an intervening `make clean`
-command. 
+command.
 
 Since the ICU build is not hermetic, this ensures there are no remnants of the
 old compilation process sitting around in the build directory.  You need to do

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -1,0 +1,20 @@
+# rust_icu_buildenv.
+FROM rust:1.40 AS buildenv
+
+RUN mkdir -p /src
+
+WORKDIR /src
+RUN ls -l && pwd && echo $PATH
+
+RUN apt-get update && apt-get install -y \
+		apt-utils \
+		clang \
+		curl \
+		git \
+		libclang-dev \
+		llvm-dev \
+		""
+
+RUN cargo version && cargo install bindgen rustfmt
+RUN rustup toolchain install nightly && rustup default nightly
+

--- a/build/Dockerfile.hermetic
+++ b/build/Dockerfile.hermetic
@@ -1,0 +1,28 @@
+# Dockerfile for building and running ICU tests.
+#
+# Intended directory layout:
+#
+# /usr/local    - installed libraries
+# /src/icu      - ICU library checkout
+# /src/rust_icu - rust_icu library checkout, source
+#
+# Build with:
+#   docker build test .
+# Run with:
+#   docker run test
+ARG DOCKER_REPO=filipfilmar
+ARG VERSION=0.0.1
+FROM $DOCKER_REPO/rust_icu_maint-64:$VERSION AS buildenv
+
+ENV RUST_ICU_SOURCE_DIR=/src/rust_icu
+ENV RUST_ICU_BUILD_DIR=/build/rust_icu
+RUN mkdir -p $RUST_ICU_BUILD_DIR && \
+		git clone "https://github.com/google/rust_icu.git" && \
+		cd $RUST_ICU_SOURCE_DIR && \
+		ln -s $RUST_ICU_BUILD_DIR target
+
+ENTRYPOINT ( \
+		cd $RUST_ICU_SOURCE_DIR; \
+		env LD_LIBRARY_PATH=/usr/local/lib cargo test; \
+		)
+

--- a/build/Dockerfile.maint-64
+++ b/build/Dockerfile.maint-64
@@ -1,0 +1,25 @@
+ARG DOCKER_REPO=filipfilmar
+ARG VERSION=0.0.0
+FROM $DOCKER_REPO/rust_icu_buildenv:$VERSION AS buildenv
+
+# Install ICU from source.
+ENV ICU_SOURCE_DIR="/src/icu"
+RUN git clone https://github.com/unicode-org/icu.git && \
+		cd $ICU_SOURCE_DIR && \
+		git fetch origin maint/maint-64 && \
+		git checkout maint/maint-64
+
+ENV ICU4C_BUILD_DIR=/build/icu4c-build
+RUN mkdir -p $ICU4C_BUILD_DIR && ls -l && \
+		pwd && \
+		cd $ICU_BUILD_DIR && \
+		env CXXFLAGS="-ggdb -DU_DEBUG=1" \
+		    $ICU_SOURCE_DIR/icu4c/source/runConfigureICU Linux \
+			  --enable-static \
+			  --prefix=/usr/local \
+			  --enable-debug && \
+		make -j && \
+		make install && \
+		icu-config --version
+
+ENTRYPOINT echo "ICU version in this container: $(icu-config --version)"

--- a/build/Dockerfile.testenv
+++ b/build/Dockerfile.testenv
@@ -1,0 +1,17 @@
+# Dockerfile for running rust_icu tests based
+# on source that has been mounted in.
+ARG DOCKER_REPO=filipfilmar
+ARG VERSION=0.0.0
+FROM $DOCKER_REPO/rust_icu_maint-64:$VERSION AS buildenv
+
+# Mount the rust_icu source top level directory here.
+ENV RUST_ICU_SOURCE_DIR=/src/rust_icu
+
+RUN mkdir -p $RUST_ICU_SOURCE_DIR
+VOLUME [ $RUST_ICU_SOURCE_DIR ]
+
+ENTRYPOINT ( \
+		cd $RUST_ICU_SOURCE_DIR; \
+		env LD_LIBRARY_PATH=/usr/local/lib cargo test; \
+		)
+

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,0 +1,21 @@
+# Uses version tag of the form buildenv-0.0.0.
+#
+RAW_VERSION := $(shell git describe --dirty --tags --match="buildenv-*")
+VERSION = $(RAW_VERSION:buildenv-%=%)
+
+# The docker repo should be a more official one.
+DOCKER_REPO ?= filipfilmar
+
+build-%: Dockerfile.%
+	docker build \
+			--build-arg DOCKER_REPO=${DOCKER_REPO} \
+			--build-arg VERSION=${VERSION} \
+			-f $< -t $*:latest .
+
+tag-%: build-%
+	docker tag $*:latest ${DOCKER_REPO}/rust_icu_$*:${VERSION}
+
+push-%: tag-%
+	docker push ${DOCKER_REPO}/rust_icu_$*:${VERSION}
+
+all: push-buildenv push-maint-64 push-hermetic push-testenv

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,38 @@
+# Docker build and test environments for `rust_icu`
+
+> See the [optional dependencies](/README.md#optional) section of the README.
+
+This directory contains the build and test environments for `rust_icu`, built
+using `docker`.  Since building and configuring ICU can be a somewhat finnicky
+endeavor, we pre-built a few docker images that already contain ICU installed
+from source.
+
+This should make it fairly easy to get started building and testing `rust_icu`.
+
+# Image registry
+
+The provided [`Makefile`](Makefile) automates build, tag and push of the build
+environment.
+
+| Name | Prebuilt | Build/push command | Purpose |
+| ---- | -------- | ------------- | ------- |
+| testenv | filipfilmar/rust_icu_testenv | `make push-testenv` | Non-hermetic test environment for locally mounted source code. Depends on `maint-64`. |
+| hermetic | filipfilmar/rust_icu_hermetic | `make push-hermetic` | A hermetic test ran completely inside the container. Depends on `maint-64`. |
+| maint-64 | filipfilmar/rust_icu_maint-64 | `make push-maint-64` | A build environment using ICU 64 maintenance branch as wrapping basis. Depends on `buildenv`. |
+| buildenv | filipfilmar/rust_icu_buildenv | `make buildenv` | The base build environment image, containing all the basic tools. All build environments, such as `maint-64` for example, use this image as basis. |
+
+# Updating the images
+
+To update all the build images, from the top level directory do the following:
+
+```bash
+cd build
+make DOCKER_REPO=yourrepo all
+```
+
+Omitting `DOCKER_REPO` will cause the push to happen to the default repository, 
+which you may not be allowed to write to.
+
+# Building the images locally
+
+It is possible to build the images locally with `docker`


### PR DESCRIPTION
Adds Docker-based build and tests, for easy start.  Handles
part of issue #31, making it easy to check out the source code and
try the library out.

Documents the details in README.md.