### PR TITLE
Improves the docker build-test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,21 +11,31 @@ else
 endif
 
 # The buildenv version that will be used to build and test.
-USED_BUILDENV_VERSION := 0.0.1
+USED_BUILDENV_VERSION := 0.0.2
 
-.PHONY: test
 test:
 	env LD_LIBRARY_PATH="$(shell icu-config --libdir)" cargo test
+.PHONY: test
 
-# Run a test inside a Docker container.
-.PHONY: docker-test
+# Run a test inside a Docker container.  The --volume mounts attach local dirs
+# so that as much as possible of the host configuration is retained.
+CARGO_TARGET_DIR := ${TMP}/rust_icu-${USER}-target
 docker-test:
+	mkdir -p ${CARGO_TARGET_DIR}
 	docker run ${TTY} \
+			--user=${UID}:${GID} \
 			--volume=${TOP_DIR}:/src/rust_icu \
+			--volume=${CARGO_TARGET_DIR}:/build/cargo \
+			--volume=${HOME}/.cargo:/usr/local/cargo \
 			${DOCKER_REPO}/rust_icu_testenv:${USED_BUILDENV_VERSION}
+.PHONY: docker-test
 
 # Builds and pushes the build environment containers.  You would not normally
 # need to do this.
-.PHONY: buildenv
 buildenv:
 	make -C build DOCKER_REPO=${DOCKER_REPO} all
+.PHONY: buildenv
+
+clean:
+	cargo clean
+.PHONY: clean

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -9,12 +9,20 @@ RUN ls -l && pwd && echo $PATH
 RUN apt-get update && apt-get install -y \
 		apt-utils \
 		clang \
+		coreutils \
 		curl \
+		exuberant-ctags \
+		gawk \
 		git \
 		libclang-dev \
 		llvm-dev \
 		""
 
-RUN cargo version && cargo install bindgen rustfmt
-RUN rustup toolchain install nightly && rustup default nightly
+RUN cargo version && \
+		cargo install bindgen rustfmt && \
+		rustup toolchain install nightly && \
+		rustup default nightly
+RUN chmod --recursive a+rwx $HOME
+RUN echo $HOME && cd && ls -ld $HOME
+
 

--- a/build/Dockerfile.maint-64
+++ b/build/Dockerfile.maint-64
@@ -10,8 +10,7 @@ RUN git clone https://github.com/unicode-org/icu.git && \
 		git checkout maint/maint-64
 
 ENV ICU4C_BUILD_DIR=/build/icu4c-build
-RUN mkdir -p $ICU4C_BUILD_DIR && ls -l && \
-		pwd && \
+RUN mkdir -p $ICU4C_BUILD_DIR && \
 		cd $ICU_BUILD_DIR && \
 		env CXXFLAGS="-ggdb -DU_DEBUG=1" \
 		    $ICU_SOURCE_DIR/icu4c/source/runConfigureICU Linux \
@@ -21,5 +20,8 @@ RUN mkdir -p $ICU4C_BUILD_DIR && ls -l && \
 		make -j && \
 		make install && \
 		icu-config --version
+
+ENV CARGO_BUILD_DIR=/build/cargo
+RUN mkdir -p $CARGO_BUILD_DIR
 
 ENTRYPOINT echo "ICU version in this container: $(icu-config --version)"

--- a/build/Dockerfile.testenv
+++ b/build/Dockerfile.testenv
@@ -6,9 +6,15 @@ FROM $DOCKER_REPO/rust_icu_maint-64:$VERSION AS buildenv
 
 # Mount the rust_icu source top level directory here.
 ENV RUST_ICU_SOURCE_DIR=/src/rust_icu
+VOLUME $RUST_ICU_SOURCE_DIR $CARGO_BUILD_DIR
 
-RUN mkdir -p $RUST_ICU_SOURCE_DIR
-VOLUME [ $RUST_ICU_SOURCE_DIR ]
+RUN umask
+RUN mkdir -p $RUST_ICU_SOURCE_DIR && \
+		chmod --recursive a+rwx \
+		  /build \
+		  /usr/local/cargo
+
+RUN ls -lR /src /build $HOME && ls -ld /
 
 ENTRYPOINT ( \
 		cd $RUST_ICU_SOURCE_DIR; \

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,7 +1,7 @@
 # Uses version tag of the form buildenv-0.0.0.
 #
 RAW_VERSION := $(shell git describe --dirty --tags --match="buildenv-*")
-VERSION = $(RAW_VERSION:buildenv-%=%)
+VERSION ?= $(RAW_VERSION:buildenv-%=%)
 
 # The docker repo should be a more official one.
 DOCKER_REPO ?= filipfilmar
@@ -19,3 +19,4 @@ push-%: tag-%
 	docker push ${DOCKER_REPO}/rust_icu_$*:${VERSION}
 
 all: push-buildenv push-maint-64 push-hermetic push-testenv
+	echo "buildenv-version: ${VERSION}"


### PR DESCRIPTION
The new setup:

- runs as the local user (instead of user root)
- mounts host source directory *and* cargo directories, so that any work
  done in the container remains usable outside of it.

This setup makes it possible to run tests inside and outside the
container, as the developer chooses to do.

The goal is the ability to run a hermetic set of tests for
different build configurations in a continuous-integration environment.