### PR TITLE
Increase version to 0.0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ publish:
 # A helper to up-rev the cargo crate versions.
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
-UPREV_OLD_VERSION ?= 0.0.5
-UPREV_NEW_VERSION ?= 0.0.6
+UPREV_OLD_VERSION ?= 0.0.6
+UPREV_NEW_VERSION ?= 0.0.7
 define uprev
 	( \
 		cd $(1) && \

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ The version semver in each cell denotes the version point that was tested.
 | ICU version | `default` | `renaming` | `renaming`, `icu_version_in_env`|
 | ----------- | ------------------- | ---------------------- | ----- |
 | 63.x        | ???                   | ???                      | ??? |
-| 64.2        | 0.0.{3,4,5}             | ???                      | ??? |
-| 65.1        | 0.0.5                 | 0.0.5                    | 0.0.5 |
-| 66.0.1      | 0.0.5                 | ???                      | ??? |
+| 64.2        | 0.0.[3-6]             | ???                      | ??? |
+| 65.1        | 0.0.6                 | 0.0.6                    | 0.0.6 |
+| 66.0.1      | 0.0.6                 | ???                      | ??? |
 
 > API versions that differ in the minor version number only should be
 > compatible; but since it is time consuming to test all versions and

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.5", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.6", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.5"
+version = "0.0.6"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.5", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.5", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.5", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.5", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.6", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.6", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.6", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.6", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.5"
+version = "0.0.6"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.5", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.5", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.0.5", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.5", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.0.5", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.5", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.6", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.6", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.0.6", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.6", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.0.6", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.6", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.5"
+version = "0.0.6"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.5", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.5", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.6", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.6", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.5"
+version = "0.0.6"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.5", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.5", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.6", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.6", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uloc"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.5"
+version = "0.0.6"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,10 +18,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.5", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.5", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.5", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.5", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.6", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.6", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.6", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.6", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.0.5"
+version = "0.0.6"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.5", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.5", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.6", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.6", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.0.5", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.5", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.0.6", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.6", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]


### PR DESCRIPTION
I'd like to push this minimal bug fix release, and then make the next release 0.1.0, reflecting the `ULoc` API changes we discussed.