### PR TITLE
[uloc] Implement new methods and standard Rust traits for ULoc

### DIFF
--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -17,6 +17,7 @@ default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
+anyhow = "1.0.25"
 thiserror = "1.0.9"
 
 rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.6", default-features = false}

--- a/rust_icu_ucal/src/lib.rs
+++ b/rust_icu_ucal/src/lib.rs
@@ -56,8 +56,7 @@ impl UCalendar {
         cal_type: sys::UCalendarType,
     ) -> Result<UCalendar, common::Error> {
         let mut status = common::Error::OK_CODE;
-        let asciiz_locale =
-            ffi::CString::new(locale).map_err(|_| common::Error::string_with_interior_nul())?;
+        let asciiz_locale = ffi::CString::new(locale).map_err(|e| common::Error::wrapper(e))?;
         // Requires that zone_id contains a valid Unicode character representation with known
         // beginning and length.  asciiz_locale must be a pointer to a valid C string.  The first
         // condition is assumed to be satisfied by ustring::UChar, and the second should be

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -23,6 +23,9 @@ rust_icu_sys = { path = "../rust_icu_sys", version = "0.0.6", default-features =
 rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.0.6", default-features = false }
 rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.0.6", default-features = false }
 
+[dev-dependencies]
+anyhow = "1.0.25"
+
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
 default = ["bindgen", "renaming", "icu_config"]

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -18,6 +18,7 @@ use {
     rust_icu_sys::*,
     rust_icu_uenum::Enumeration,
     std::{
+        cmp::Ordering,
         convert::{From, TryFrom, TryInto},
         ffi,
         os::raw,
@@ -31,7 +32,10 @@ const LOCALE_CAPACITY: usize = 158;
 /// A representation of a Unicode locale.
 ///
 /// For the time being, only basic conversion and methods are in fact implemented.
-#[derive(Debug, Eq, PartialEq)]
+///
+/// To get basic validation when creating a locale, use
+/// [`for_language_tag`](ULoc::for_language_tag) with a Unicode BCP-47 locale ID.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ULoc {
     // A locale's representation in C is really just a string.
     repr: String,
@@ -53,9 +57,7 @@ impl TryFrom<&ffi::CStr> for ULoc {
 
     /// Creates a new `ULoc` from a borrowed C string.
     fn try_from(s: &ffi::CStr) -> Result<Self, Self::Error> {
-        let repr = s
-            .to_str()
-            .map_err(|_| common::Error::string_with_interior_nul())?;
+        let repr = s.to_str()?;
         ULoc {
             repr: String::from(repr),
         }
@@ -135,12 +137,12 @@ macro_rules! buffered_string_method_with_retry {
                (common::Error::is_ok(status) &&
                     full_len > $buffer_capacity
                         .try_into()
-                        .map_err(|e| common::Error::wrapper(format!("{:?}", e)))?) {
+                        .map_err(|e| common::Error::wrapper(e))?) {
 
                 assert!(full_len > 0);
                 let full_len: usize = full_len
                     .try_into()
-                    .map_err(|e| common::Error::wrapper(format!("{:?}", e)))?;
+                    .map_err(|e| common::Error::wrapper(e))?;
                 buf.resize(full_len, 0);
 
                 // Same unsafe requirements as above, plus full_len must be exactly the output
@@ -163,33 +165,33 @@ macro_rules! buffered_string_method_with_retry {
             if (full_len >= 0) {
                 let full_len: usize = full_len
                     .try_into()
-                    .map_err(|e| common::Error::wrapper(format!("{:?}", e)))?;
+                    .map_err(|e| common::Error::wrapper(e))?;
                 buf.resize(full_len, 0);
             }
-            String::from_utf8(buf).map_err(|_| common::Error::string_with_interior_nul())
+            String::from_utf8(buf).map_err(|e| e.utf8_error().into())
         }
     }
 }
 
 impl ULoc {
     /// Implements `uloc_getLanguage`.
-    pub fn language(&self) -> Result<String, common::Error> {
-        self.call_buffered_string_method(versioned_function!(uloc_getLanguage))
+    pub fn language(&self) -> Option<String> {
+        self.call_buffered_string_method_to_option(versioned_function!(uloc_getLanguage))
     }
 
     /// Implements `uloc_getScript`.
-    pub fn script(&self) -> Result<String, common::Error> {
-        self.call_buffered_string_method(versioned_function!(uloc_getScript))
+    pub fn script(&self) -> Option<String> {
+        self.call_buffered_string_method_to_option(versioned_function!(uloc_getScript))
     }
 
     /// Implements `uloc_getCountry`.
-    pub fn country(&self) -> Result<String, common::Error> {
-        self.call_buffered_string_method(versioned_function!(uloc_getCountry))
+    pub fn country(&self) -> Option<String> {
+        self.call_buffered_string_method_to_option(versioned_function!(uloc_getCountry))
     }
 
     /// Implements `uloc_getVariant`.
-    pub fn variant(&self) -> Result<String, common::Error> {
-        self.call_buffered_string_method(versioned_function!(uloc_getVariant))
+    pub fn variant(&self) -> Option<String> {
+        self.call_buffered_string_method_to_option(versioned_function!(uloc_getVariant))
     }
 
     /// Implements `uloc_canonicalize` from ICU4C.
@@ -210,7 +212,7 @@ impl ULoc {
             .map(|repr| ULoc { repr })
     }
 
-    // Implements `uloc_toLanguageTag` from ICU4C.
+    /// Implements `uloc_toLanguageTag` from ICU4C.
     pub fn to_language_tag(&self, strict: bool) -> Result<String, common::Error> {
         buffered_string_method_with_retry!(
             buffered_string_to_language_tag,
@@ -229,6 +231,57 @@ impl ULoc {
         )
     }
 
+    /// Implements `uloc_openKeywords()` from ICU4C.
+    pub fn keywords(&self) -> impl Iterator<Item = String> {
+        rust_icu_uenum::uloc_open_keywords(&self.repr)
+            .unwrap()
+            .map(|result| result.unwrap())
+    }
+
+    /// Implements `icu::Locale::getUnicodeKeywords()` from the C++ API.
+    pub fn unicode_keywords(&self) -> impl Iterator<Item = String> {
+        self.keywords().filter_map(|s| to_unicode_locale_key(&s))
+    }
+
+    /// Implements `uloc_getKeywordValue()` from ICU4C.
+    pub fn keyword_value(&self, keyword: &str) -> Result<Option<String>, common::Error> {
+        buffered_string_method_with_retry!(
+            buffered_string_keyword_value,
+            LOCALE_CAPACITY,
+            [
+                locale_id: *const raw::c_char,
+                keyword_name: *const raw::c_char,
+            ],
+            []
+        );
+        let locale_id = self.as_c_str();
+        let keyword_name = str_to_cstring(keyword);
+        buffered_string_keyword_value(
+            versioned_function!(uloc_getKeywordValue),
+            locale_id.as_ptr(),
+            keyword_name.as_ptr(),
+        )
+        .map(|value| if value.is_empty() { None } else { Some(value) })
+    }
+
+    /// Implements `icu::Locale::getUnicodeKeywordValue()` from ICU4C.
+    pub fn unicode_keyword_value(
+        &self,
+        unicode_keyword: &str,
+    ) -> Result<Option<String>, common::Error> {
+        let legacy_keyword = to_legacy_key(unicode_keyword);
+        match legacy_keyword {
+            Some(legacy_keyword) => match self.keyword_value(&legacy_keyword) {
+                Ok(Some(legacy_value)) => {
+                    Ok(to_unicode_locale_type(&legacy_keyword, &legacy_value))
+                }
+                Ok(None) => Ok(None),
+                Err(e) => Err(e),
+            },
+            None => Ok(None),
+        }
+    }
+
     /// Returns the current label of this locale.
     pub fn label(&self) -> &str {
         &self.repr
@@ -239,13 +292,22 @@ impl ULoc {
         ffi::CString::new(self.repr.clone()).expect("ULoc contained interior NUL bytes")
     }
 
-    // Implements `uloc_acceptLanguage` from ICU4C.
-    #[deprecated = "Use `rust_icu_uloc::accept_language`"]
-    pub fn accept_language(
-        accept_list: impl IntoIterator<Item = impl Into<ULoc>>,
-        available_locales: impl IntoIterator<Item = impl Into<ULoc>>,
-    ) -> Result<(Option<ULoc>, UAcceptResult), common::Error> {
-        accept_language(accept_list, available_locales)
+    /// Implements `uloc_forLanguageTag` from ICU4C.
+    pub fn for_language_tag(tag: &str) -> Result<ULoc, common::Error> {
+        buffered_string_method_with_retry!(
+            buffered_string_for_language_tag,
+            LOCALE_CAPACITY,
+            [tag: *const raw::c_char,],
+            [parsed_length: *mut i32,]
+        );
+
+        let tag = str_to_cstring(tag);
+        let locale_id = buffered_string_for_language_tag(
+            versioned_function!(uloc_forLanguageTag),
+            tag.as_ptr(),
+            std::ptr::null_mut(),
+        )?;
+        ULoc::try_from(&locale_id[..])
     }
 
     /// Call a `uloc` method that takes this locale's ID and returns a string.
@@ -267,6 +329,91 @@ impl ULoc {
         let asciiz = self.as_c_str();
         buffered_string_char_star(uloc_method, asciiz.as_ptr())
     }
+
+    /// Call a `uloc` method that takes this locale's ID, panics on any errors, and returns
+    /// `Some(result)` if the resulting string is non-empty, or `None` otherwise.
+    fn call_buffered_string_method_to_option(
+        &self,
+        uloc_method: unsafe extern "C" fn(
+            *const raw::c_char,
+            *mut raw::c_char,
+            i32,
+            *mut UErrorCode,
+        ) -> i32,
+    ) -> Option<String> {
+        let value: String = self.call_buffered_string_method(uloc_method).unwrap();
+        if value.is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    }
+}
+
+/// This implementation is based on ULocale.compareTo from ICU4J.
+/// See https://github.com/unicode-org/icu/blob/master/icu4j/main/classes/core/src/com/ibm/icu/util/ULocale.java
+impl Ord for ULoc {
+    fn cmp(&self, other: &Self) -> Ordering {
+        /// Compare corresponding keywords from two `ULoc`s. If the keywords match, compare the
+        /// keyword values.
+        fn compare_keywords(
+            this: &ULoc,
+            self_keyword: &Option<String>,
+            other: &ULoc,
+            other_keyword: &Option<String>,
+        ) -> Option<Ordering> {
+            match (self_keyword, other_keyword) {
+                (Some(self_keyword), Some(other_keyword)) => {
+                    // Compare the two keywords
+                    match self_keyword.cmp(&other_keyword) {
+                        Ordering::Equal => {
+                            // Compare the two keyword values
+                            let self_val = this.keyword_value(&self_keyword[..]).unwrap();
+                            let other_val = other.keyword_value(&other_keyword[..]).unwrap();
+                            Some(self_val.cmp(&other_val))
+                        }
+                        unequal_ordering => Some(unequal_ordering),
+                    }
+                }
+                // `other` has run out of keywords
+                (Some(_), _) => Some(Ordering::Greater),
+                // `this` has run out of keywords
+                (_, Some(_)) => Some(Ordering::Less),
+                // Both iterators have run out
+                (_, _) => None,
+            }
+        }
+
+        self.language()
+            .cmp(&other.language())
+            .then_with(|| self.script().cmp(&other.script()))
+            .then_with(|| self.country().cmp(&other.country()))
+            .then_with(|| self.variant().cmp(&other.variant()))
+            .then_with(|| {
+                let mut self_keywords = self.keywords();
+                let mut other_keywords = other.keywords();
+
+                while let Some(keyword_ordering) =
+                    compare_keywords(self, &self_keywords.next(), other, &other_keywords.next())
+                {
+                    match keyword_ordering {
+                        Ordering::Equal => {}
+                        unequal_ordering => {
+                            return unequal_ordering;
+                        }
+                    }
+                }
+
+                // All keywords and values were identical (or there were none)
+                Ordering::Equal
+            })
+    }
+}
+
+impl PartialOrd for ULoc {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 /// Gets the current system default locale.
@@ -283,13 +430,12 @@ pub fn get_default() -> ULoc {
 /// Implements `uloc_setDefault` from ICU4C.
 pub fn set_default(loc: &ULoc) -> Result<(), common::Error> {
     let mut status = common::Error::OK_CODE;
-    let asciiz = ffi::CString::new(loc.repr.clone())
-        .map_err(|_| common::Error::string_with_interior_nul())?;
+    let asciiz = str_to_cstring(&loc.repr);
     unsafe { versioned_function!(uloc_setDefault)(asciiz.as_ptr(), &mut status) };
     common::Error::ok_or_warning(status)
 }
 
-// Implements `uloc_acceptLanguage` from ICU4C.
+/// Implements `uloc_acceptLanguage` from ICU4C.
 pub fn accept_language(
     accept_list: impl IntoIterator<Item = impl Into<ULoc>>,
     available_locales: impl IntoIterator<Item = impl Into<ULoc>>,
@@ -346,43 +492,111 @@ pub fn accept_language(
         .map(|uloc| (Some(uloc), accept_result))
 }
 
+/// Implements `uloc_toUnicodeLocaleKey` from ICU4C.
+pub fn to_unicode_locale_key(legacy_keyword: &str) -> Option<String> {
+    let legacy_keyword = str_to_cstring(legacy_keyword);
+    let unicode_keyword: Option<ffi::CString> = unsafe {
+        let ptr = versioned_function!(uloc_toUnicodeLocaleKey)(legacy_keyword.as_ptr());
+        ptr.as_ref().map(|ptr| ffi::CStr::from_ptr(ptr).to_owned())
+    };
+    unicode_keyword.map(|cstring| cstring_to_string(&cstring))
+}
+
+/// Implements `uloc_toUnicodeLocaleType` from ICU4C.
+pub fn to_unicode_locale_type(legacy_keyword: &str, legacy_value: &str) -> Option<String> {
+    let legacy_keyword = str_to_cstring(legacy_keyword);
+    let legacy_value = str_to_cstring(legacy_value);
+    let unicode_value: Option<ffi::CString> = unsafe {
+        let ptr = versioned_function!(uloc_toUnicodeLocaleType)(
+            legacy_keyword.as_ptr(),
+            legacy_value.as_ptr(),
+        );
+        ptr.as_ref().map(|ptr| ffi::CStr::from_ptr(ptr).to_owned())
+    };
+    unicode_value.map(|cstring| cstring_to_string(&cstring))
+}
+
+/// Implements `uloc_toLegacyKey` from ICU4C.
+pub fn to_legacy_key(unicode_keyword: &str) -> Option<String> {
+    let unicode_keyword = str_to_cstring(unicode_keyword);
+    let legacy_keyword: Option<ffi::CString> = unsafe {
+        let ptr = versioned_function!(uloc_toLegacyKey)(unicode_keyword.as_ptr());
+        ptr.as_ref().map(|ptr| ffi::CStr::from_ptr(ptr).to_owned())
+    };
+    legacy_keyword.map(|cstring| cstring_to_string(&cstring))
+}
+
+/// Infallibly converts a Rust string to a `CString`. If there's an interior NUL, the string is
+/// truncated up to that point.
+fn str_to_cstring(input: &str) -> ffi::CString {
+    ffi::CString::new(input)
+        .unwrap_or_else(|e| ffi::CString::new(&input[0..e.nul_position()]).unwrap())
+}
+
+/// Infallibly converts a `CString` to a Rust `String`. We can safely assume that any strings
+/// coming from ICU data are valid UTF-8.
+fn cstring_to_string(input: &ffi::CString) -> String {
+    input.to_string_lossy().to_string()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, anyhow::Error};
 
     #[test]
-    fn test_language() {
-        let loc = ULoc::try_from("es-CO").expect("get es_CO locale");
-        let language = loc.language().expect("should get language");
-        assert_eq!(&language, "es");
+    fn test_language() -> Result<(), Error> {
+        let loc = ULoc::try_from("es-CO")?;
+        assert_eq!(loc.language(), Some("es".to_string()));
+        Ok(())
     }
 
     #[test]
-    fn test_script() {
-        let loc = ULoc::try_from("sr-Cyrl").expect("get sr_Cyrl locale");
-        let script = loc.script().expect("should get script");
-        assert_eq!(&script, "Cyrl");
+    fn test_language_absent() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("und-CO")?;
+        assert_eq!(loc.language(), None);
+        Ok(())
     }
 
     #[test]
-    fn test_script_absent() {
-        let loc = ULoc::try_from("sr").expect("get sr locale");
-        let script = loc.script().expect("should get script");
-        assert_eq!(&script, "");
+    fn test_script() -> Result<(), Error> {
+        let loc = ULoc::try_from("sr-Cyrl")?;
+        assert_eq!(loc.script(), Some("Cyrl".to_string()));
+        Ok(())
     }
 
     #[test]
-    fn test_country() {
-        let loc = ULoc::try_from("es-CO").expect("get es_CO locale");
-        let country = loc.country().expect("should get country");
-        assert_eq!(&country, "CO");
+    fn test_script_absent() -> Result<(), Error> {
+        let loc = ULoc::try_from("sr")?;
+        assert_eq!(loc.script(), None);
+        Ok(())
     }
 
     #[test]
-    fn test_variant() {
-        let loc = ULoc::try_from("zh-Latn-pinyin").expect("get zh_Latn_pinyin locale");
-        let variant = loc.variant().expect("should get variant");
-        assert_eq!(&variant, "PINYIN");
+    fn test_country() -> Result<(), Error> {
+        let loc = ULoc::try_from("es-CO")?;
+        assert_eq!(loc.country(), Some("CO".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_country_absent() -> Result<(), Error> {
+        let loc = ULoc::try_from("es")?;
+        assert_eq!(loc.country(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_variant() -> Result<(), Error> {
+        let loc = ULoc::try_from("zh-Latn-pinyin")?;
+        assert_eq!(loc.variant(), Some("PINYIN".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_variant_absent() -> Result<(), Error> {
+        let loc = ULoc::try_from("zh-Latn")?;
+        assert_eq!(loc.variant(), None);
+        Ok(())
     }
 
     #[test]
@@ -419,6 +633,102 @@ mod tests {
             .to_language_tag(true)
             .expect("should convert to language tag");
         assert_eq!(language_tag, "sr-Cyrl-RS".to_string());
+    }
+
+    #[test]
+    fn test_keywords() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("az-Cyrl-AZ-u-ca-hebrew-fw-sunday-nu-deva-tz-usnyc")?;
+        let keywords: Vec<String> = loc.keywords().collect();
+        assert_eq!(
+            keywords,
+            vec![
+                "calendar".to_string(),
+                "fw".to_string(),
+                "numbers".to_string(),
+                "timezone".to_string()
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_keywords_empty() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("az-Cyrl-AZ")?;
+        let keywords: Vec<String> = loc.keywords().collect();
+        assert!(keywords.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_unicode_keywords() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("az-Cyrl-AZ-u-ca-hebrew-fw-sunday-nu-deva-tz-usnyc")?;
+        let keywords: Vec<String> = loc.unicode_keywords().collect();
+        assert_eq!(
+            keywords,
+            vec![
+                "ca".to_string(),
+                "fw".to_string(),
+                "nu".to_string(),
+                "tz".to_string()
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_unicode_keywords_empty() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("az-Cyrl-AZ")?;
+        let keywords: Vec<String> = loc.unicode_keywords().collect();
+        assert!(keywords.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_keyword_value() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("az-Cyrl-AZ-u-ca-hebrew-fw-sunday-nu-deva-tz-usnyc")?;
+        assert_eq!(loc.keyword_value("calendar")?, Some("hebrew".to_string()));
+        assert_eq!(loc.keyword_value("collation")?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_unicode_keyword_value() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("az-Cyrl-AZ-u-ca-hebrew-fw-sunday-nu-deva-tz-usnyc")?;
+        assert_eq!(loc.unicode_keyword_value("ca")?, Some("hebrew".to_string()));
+        assert_eq!(loc.unicode_keyword_value("fw")?, Some("sunday".to_string()));
+        assert_eq!(loc.unicode_keyword_value("co")?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_order() -> Result<(), Error> {
+        assert!(ULoc::for_language_tag("az")? < ULoc::for_language_tag("az-Cyrl")?);
+        assert!(ULoc::for_language_tag("az-Cyrl")? < ULoc::for_language_tag("az-Cyrl-AZ")?);
+        assert!(
+            ULoc::for_language_tag("az-Cyrl-AZ")? < ULoc::for_language_tag("az-Cyrl-AZ-variant")?
+        );
+        assert!(
+            ULoc::for_language_tag("az-Cyrl-AZ-variant")?
+                < ULoc::for_language_tag("az-Cyrl-AZ-variant-u-nu-arab")?
+        );
+        assert!(
+            ULoc::for_language_tag("az-u-ca-gregory")? < ULoc::for_language_tag("az-u-fw-fri")?
+        );
+        assert!(
+            ULoc::for_language_tag("az-u-ca-buddhist")?
+                < ULoc::for_language_tag("az-u-ca-chinese")?
+        );
+        assert!(ULoc::for_language_tag("az-u-fw-mon")? < ULoc::for_language_tag("az-u-fw-tue")?);
+        assert!(
+            ULoc::for_language_tag("az-u-fw-mon")? < ULoc::for_language_tag("az-u-fw-mon-nu-arab")?
+        );
+        assert!(
+            ULoc::for_language_tag("az-u-fw-mon-nu-arab")? > ULoc::for_language_tag("az-u-fw-mon")?
+        );
+
+        let loc = ULoc::for_language_tag("az-Cyrl-AZ-variant-u-nu-arab")?;
+        assert_eq!(loc.cmp(&loc), Ordering::Equal,);
+        Ok(())
     }
 
     #[test]
@@ -484,5 +794,34 @@ mod tests {
 
         let actual = accept_language(accept_list, available_locales).expect("call accept_language");
         assert_eq!(actual, (None, UAcceptResult::ULOC_ACCEPT_FAILED))
+    }
+
+    #[test]
+    fn test_to_unicode_locale_key() -> Result<(), Error> {
+        let actual = to_unicode_locale_key("calendar");
+        assert_eq!(actual, Some("ca".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_to_unicode_locale_type() -> Result<(), Error> {
+        let actual = to_unicode_locale_type("co", "phonebook");
+        assert_eq!(actual, Some("phonebk".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_to_legacy_key() -> Result<(), Error> {
+        let actual = to_legacy_key("ca");
+        assert_eq!(actual, Some("calendar".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_str_to_cstring() -> Result<(), Error> {
+        assert_eq!(str_to_cstring("abc"), ffi::CString::new("abc")?);
+        assert_eq!(str_to_cstring("abc\0def"), ffi::CString::new("abc")?);
+
+        Ok(())
     }
 }

--- a/rust_icu_ustring/src/lib.rs
+++ b/rust_icu_ustring/src/lib.rs
@@ -146,7 +146,7 @@ impl TryFrom<&UChar> for String {
         common::Error::ok_or_warning(status)?;
         let s = String::from_utf8(buf);
         match s {
-            Err(_) => Err(common::Error::wrapper("could not convert to utf8")),
+            Err(e) => Err(e.into()),
             Ok(x) => {
                 trace!("result UChar*->utf8: {:?}", x);
                 Ok(x)


### PR DESCRIPTION
- `ULoc` traits: `Hash`, `Eq`, `PartialEq`, `Ord`, `PartialOrd`
- `ULoc` methods:
  - `keywords`, `keyword_value`, `unicode_keywords`, `unicode_keyword_value`
  - `for_language_tag` (factory method)
  - Change some getters to return `Option<String>` instead of `Result<String, Error>` with possibly empty strings
- Crate functions:
  - `to_unicode_locale_key`
  - `to_unicode_locale_type`
  - `to_legacy_key`