### PR TITLE
Starts testing the library with ICU 63

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
 rust:
   - nightly
 env:
+  - DOCKER_TEST_ENV=rust_icu_testenv-63
   - DOCKER_TEST_ENV=rust_icu_testenv-64
   - DOCKER_TEST_ENV=rust_icu_testenv-65
   - DOCKER_TEST_ENV=rust_icu_testenv-66

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ headers of columns 2 and onwards are features set combos.  The coverage
 reflects the feature set and version points that we needed up to this point.
 The version semver in each cell denotes the version point that was tested.
 
-| ICU version | `default` | `renaming` | `renaming`, `icu_version_in_env`|
-| ----------- | ------------------- | ---------------------- | ----- |
-| 63.x        | ???                   | ???                      | ??? |
-| 64.2        | 0.1.0                 | ???                      | ??? |
-| 65.1        | 0.1.0                 | 0.1.0                    | 0.1.0 |
-| 66.0.1      | 0.1.0                 | ???                      | ??? |
+| ICU version | `default`           | `renaming`             | `renaming`, `icu_version_in_env`|
+| ----------- | ------------------- | ---------------------- | ------------------------------- |
+| 63.x        | 0.1.1               | 0.1.1                  | 0.1.1                           |
+| 64.2        | 0.1.1               | N/A                    | ???                             |
+| 65.1        | 0.1.1               | 0.1.1                  | 0.1.1                           |
+| 66.0.1      | 0.1.1               | N/A                    | N/A                             |
 
 > API versions that differ in the minor version number only should be
 > compatible; but since it is time consuming to test all versions and

--- a/build/Makefile
+++ b/build/Makefile
@@ -36,6 +36,8 @@ push-%: tag-%
 
 all: \
 	push-buildenv \
+	push-maint-63 \
+	push-testenv-63 \
 	push-maint-64 \
 	push-testenv-64 \
 	push-maint-65 \


### PR DESCRIPTION
Looking into a resolution of issue #41, seems like we'd need
to modify the build environment of `docs.rs` to include the
development ICU library.  Looking at the packages available,
it seems that this is going to have to be ICU version 63.

Hence, adding the build and test envs with ICU 63.  They will be
linked into the build process as a followup.