### PR TITLE
Use `bindgen` library to generate bindings

### DIFF
--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -24,8 +24,8 @@ rust_icu_sys = { path = "../rust_icu_sys", version = "0.1.1", default-features =
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["bindgen", "renaming", "icu_config"]
-bindgen = ["rust_icu_sys/bindgen"]
+default = ["use-bindgen", "renaming", "icu_config"]
+use-bindgen = ["rust_icu_sys/use-bindgen"]
 renaming = ["rust_icu_sys/renaming"]
 icu_config = ["rust_icu_sys/icu_config"]
 icu_version_in_env = ["rust_icu_sys/icu_version_in_env"]

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -22,17 +22,18 @@ paste = "0.1.5"
 
 [build-dependencies]
 anyhow = "1.0"
+bindgen = "0.53.2"
 
 [lib]
 # Indented documentation text in the generated library is prose, not rust code.
-# See https://github.com/rust-lang/rust-bindgen/issues/378
+# See https://github.com/rust-lang/rust-use-bindgen/issues/378
 doctest = false
 
 # Please see https://github.com/google/rust_icu#features for the explanation
 # of these features.
 [features]
-default = ["bindgen", "renaming", "icu_config"]
-bindgen = []
+default = ["use-bindgen", "renaming", "icu_config"]
+use-bindgen = []
 renaming = []
 icu_config = []
 icu_version_in_env = []

--- a/rust_icu_sys/src/lib.rs
+++ b/rust_icu_sys/src/lib.rs
@@ -20,21 +20,18 @@
     unused_imports
 )]
 
-#[cfg(features = "bindgen")]
+#[cfg(features = "use-bindgen")]
 include!(concat!(env!("OUT_DIR"), "/macros.rs"));
-#[cfg(all(features = "bindgen",features="icu_config",not(features="icu_version_in_env")))]
+#[cfg(all(features = "use-bindgen",features="icu_config",not(features="icu_version_in_env")))]
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
-// Linker trickery to ensure that we link against correct libraries.
-#[cfg(all(features = "bindgen",features="icu_config",not(features="icu_version_in_env")))]
-include!(concat!(env!("OUT_DIR"), "/link.rs"));
 
-#[cfg(not(features = "bindgen"))]
+#[cfg(not(features = "use-bindgen"))]
 include!("../bindgen/macros.rs");
 
-#[cfg(all(not(features = "bindgen"),not(features="icu_version_in_env"),not(features="icu_config")))]
+#[cfg(all(not(features = "use-bindgen"),not(features="icu_version_in_env"),not(features="icu_config")))]
 include!("../bindgen/lib.rs");
 
-#[cfg(all(not(features="bindgen"),features="icu_version_in_env",not(features="icu_config")))]
+#[cfg(all(not(features="use-bindgen"),features="icu_version_in_env",not(features="icu_config")))]
 include!(concat!("../bindgen/lib_", env!("RUST_ICU_MAJOR_VERSION_NUMBER"), ".rs"));
 
 // Add the ability to print the error code, so that it can be reported in

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -28,13 +28,13 @@ regex = "1"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["bindgen", "renaming", "icu_config"]
+default = ["use-bindgen", "renaming", "icu_config"]
 
-bindgen = [
-  "rust_icu_common/bindgen",
-  "rust_icu_sys/bindgen",
-  "rust_icu_uenum/bindgen",
-  "rust_icu_ustring/bindgen",
+use-bindgen = [
+  "rust_icu_common/use-bindgen",
+  "rust_icu_sys/use-bindgen",
+  "rust_icu_uenum/use-bindgen",
+  "rust_icu_ustring/use-bindgen",
 ]
 renaming = [
   "rust_icu_common/renaming",

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -27,15 +27,15 @@ rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.1.1", default-fe
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["bindgen", "renaming", "icu_config"]
+default = ["use-bindgen", "renaming", "icu_config"]
 
-bindgen = [
-  "rust_icu_common/bindgen",
-  "rust_icu_sys/bindgen",
-  "rust_icu_ucal/bindgen",
-  "rust_icu_uenum/bindgen",
-  "rust_icu_uloc/bindgen",
-  "rust_icu_ustring/bindgen",
+use-bindgen = [
+  "rust_icu_common/use-bindgen",
+  "rust_icu_sys/use-bindgen",
+  "rust_icu_ucal/use-bindgen",
+  "rust_icu_uenum/use-bindgen",
+  "rust_icu_uloc/use-bindgen",
+  "rust_icu_ustring/use-bindgen",
 ]
 renaming = [
   "rust_icu_common/renaming",

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -23,9 +23,9 @@ rust_icu_sys = { path = "../rust_icu_sys", version = "0.1.1", default-features =
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["bindgen", "renaming", "icu_config"]
+default = ["use-bindgen", "renaming", "icu_config"]
 
-bindgen = ["rust_icu_sys/bindgen", "rust_icu_common/bindgen"]
+use-bindgen = ["rust_icu_sys/use-bindgen", "rust_icu_common/use-bindgen"]
 renaming = ["rust_icu_sys/renaming", "rust_icu_common/renaming"]
 icu_config = ["rust_icu_sys/icu_config", "rust_icu_common/icu_config"]
 icu_version_in_env = ["rust_icu_sys/icu_version_in_env", "rust_icu_common/icu_version_in_env"]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -22,9 +22,9 @@ rust_icu_common = { path = "../rust_icu_common", version = "0.1.1", default-feat
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["bindgen", "renaming", "icu_config"]
+default = ["use-bindgen", "renaming", "icu_config"]
 
-bindgen = ["rust_icu_sys/bindgen", "rust_icu_common/bindgen"]
+use-bindgen = ["rust_icu_sys/use-bindgen", "rust_icu_common/use-bindgen"]
 renaming = ["rust_icu_sys/renaming", "rust_icu_common/renaming"]
 icu_config = ["rust_icu_sys/icu_config", "rust_icu_common/icu_config"]
 icu_version_in_env = ["rust_icu_sys/icu_version_in_env", "rust_icu_common/icu_version_in_env"]

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -28,13 +28,13 @@ anyhow = "1.0.25"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["bindgen", "renaming", "icu_config"]
+default = ["use-bindgen", "renaming", "icu_config"]
 
-bindgen = [
-  "rust_icu_common/bindgen",
-  "rust_icu_sys/bindgen",
-  "rust_icu_uenum/bindgen",
-  "rust_icu_ustring/bindgen",
+use-bindgen = [
+  "rust_icu_common/use-bindgen",
+  "rust_icu_sys/use-bindgen",
+  "rust_icu_uenum/use-bindgen",
+  "rust_icu_ustring/use-bindgen",
 ]
 renaming = [
   "rust_icu_common/renaming",

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -30,9 +30,9 @@ rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.1.0", default-features
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["bindgen", "renaming", "icu_config"]
+default = ["use-bindgen", "renaming", "icu_config"]
 
-bindgen = ["rust_icu_sys/bindgen", "rust_icu_common/bindgen"]
+use-bindgen = ["rust_icu_sys/use-bindgen", "rust_icu_common/use-bindgen"]
 renaming = ["rust_icu_sys/renaming", "rust_icu_common/renaming"]
 icu_config = ["rust_icu_sys/icu_config", "rust_icu_common/icu_config"]
 icu_version_in_env = ["rust_icu_sys/icu_version_in_env", "rust_icu_common/icu_version_in_env"]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -23,9 +23,9 @@ rust_icu_sys = { path = "../rust_icu_sys", version = "0.1.1", default-features =
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["bindgen", "renaming", "icu_config"]
+default = ["use-bindgen", "renaming", "icu_config"]
 
-bindgen = ["rust_icu_sys/bindgen", "rust_icu_common/bindgen"]
+use-bindgen = ["rust_icu_sys/use-bindgen", "rust_icu_common/use-bindgen"]
 renaming = ["rust_icu_sys/renaming", "rust_icu_common/renaming"]
 icu_config = ["rust_icu_sys/icu_config", "rust_icu_common/icu_config"]
 icu_version_in_env = ["rust_icu_sys/icu_version_in_env", "rust_icu_common/icu_version_in_env"]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -22,9 +22,9 @@ rust_icu_sys = { path = "../rust_icu_sys", version = "0.1.1", default-features =
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["bindgen", "renaming", "icu_config"]
+default = ["use-bindgen", "renaming", "icu_config"]
 
-bindgen = ["rust_icu_sys/bindgen", "rust_icu_common/bindgen"]
+use-bindgen = ["rust_icu_sys/use-bindgen", "rust_icu_common/use-bindgen"]
 renaming = ["rust_icu_sys/renaming", "rust_icu_common/renaming"]
 icu_config = ["rust_icu_sys/icu_config", "rust_icu_common/icu_config"]
 icu_version_in_env = ["rust_icu_sys/icu_version_in_env", "rust_icu_common/icu_version_in_env"]


### PR DESCRIPTION
Uses the `bindgen` library, instead of a `bindgen` executable
to generate the library bindings.

This helps in issue #41, working towards a set of crates with
documentation that compiles on `docs.rs`.  Also, it places the
responsiblity for bindgen versioning in the hands of cargo, which
is better than needing to have the correct version installed.