### PR TITLE
Fixes broken test behaviors on old and new ICUs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,14 @@ endif
 # NOTE: This version number is completely independent of the crate version.
 USED_BUILDENV_VERSION ?= 0.0.4
 
+CARGO_FEATURE_VERSION :=
+
 ICU_LIBDIR := $(shell icu-config --libdir)
 test:
-	env PKG_CONFIG_PATH="${HOME}/local/lib/pkgconfig" \
+	@env PKG_CONFIG_PATH="${HOME}/local/lib/pkgconfig" \
 	    LD_LIBRARY_PATH="${ICU_LIBDIR}" \
-		cargo test
+		echo "ICU version detected: $(shell icu-config --version)" && \
+		  cargo test
 .PHONY: test
 
 # Run a test inside a Docker container.  The --volume mounts attach local dirs

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 | Item | Description |
 | ---- | ----------- |
-| ICU 64/65/66 | [![Build Status `master`](https://travis-ci.org/google/rust_icu.svg?branch=master)](https://travis-ci.org/google/rust_icu) |
+| ICU 64..67 | [![Build Status `master`](https://travis-ci.org/google/rust_icu.svg?branch=master)](https://travis-ci.org/google/rust_icu) |
 | Source | https://github.com/google/rust_icu |
 | README | https://github.com/google/rust_icu/blob/master/README.md |
 | Coverage | [View report](/coverage/report.md)
-| Docs | https://github.com/google/rust_icu/blob/master/docs/README.md |
+| Docs | https://docs.rs/crate/rust_icu |
 
 This is a library of low level native rust language bindings for the
 International Components for Unicode (ICU) library for C (a.k.a. ICU4C).
@@ -98,12 +98,13 @@ headers of columns 2 and onwards are features set combos.  The coverage
 reflects the feature set and version points that we needed up to this point.
 The version semver in each cell denotes the version point that was tested.
 
-| ICU version | `default` | `renaming` | `renaming`, `icu_version_in_env`|
-| ----------- | ------------------- | ---------------------- | ----- |
-| 63.x        | ???                   | ???                      | ??? |
-| 64.2        | 0.1.3                 | ???                      | ??? |
-| 65.1        | 0.1.3                 | 0.1.3                    | 0.1.3 |
-| 66.0.1      | 0.1.3                 | ???                      | ??? |
+| ICU version | `default` | `renaming` | `renaming`, `icu_version_in_env`  |
+| ----------- | ----------| ---------- | --------------------------------- |
+| 63.x        | ???       |  -         |  -                                |
+| 64.2        | 0.1.3+    |  -         |  -                                |
+| 65.1        | 0.1.3+    | 0.1.3+     | 0.1.3+                            |
+| 66.0.1      | 0.1.3+    |  -         |  -                                |
+| 67.1        | 0.1.4     |  -         |  -                                |
 
 > API versions that differ in the minor version number only should be
 > compatible; but since it is time consuming to test all versions and

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -127,6 +127,11 @@ impl ICUConfig {
             .with_context(|| format!("could not parse version number: {}", version))?;
         Ok(last.to_string())
     }
+    
+    fn version_major_int() -> Result<i32> {
+        let version_str = ICUConfig::version_major()?;
+        Ok(version_str.parse().unwrap())
+    }
 }
 
 /// Returns true if the ICU library was compiled with renaming enabled.
@@ -320,6 +325,9 @@ fn copy_features() -> Result<()> {
     }
     if let Some(_) = env::var_os("CARGO_FEATURE_ICU_VERSION_IN_ENV") {
         println!("cargo:rustc-cfg=features=\"icu_version_in_env\"");
+    }
+    if ICUConfig::version_major_int()? >= 67 {
+        println!("cargo:rustc-cfg=features=\"icu_version_67_plus\"");
     }
     Ok(())
 }

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Google Inc."]
 edition = "2018"
 license = "Apache-2.0"
 name = "rust_icu_uloc"
+build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
 version = "0.1.3"
@@ -54,6 +55,12 @@ icu_version_in_env = [
   "rust_icu_uenum/icu_version_in_env",
   "rust_icu_ustring/icu_version_in_env",
 ]
+icu_version_64_plus = []
+icu_version_67_plus = []
+
+[build-dependencies]
+anyhow = "1.0"
+bindgen = "0.53.2"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_uloc/build.rs
+++ b/rust_icu_uloc/build.rs
@@ -1,0 +1,109 @@
+#![feature(try_trait)]
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// See LICENSE for licensing information.
+//
+// This build.rs script tries to generate low-level rust bindings for the current ICU library.
+// Please refer to README.md for instructions on how to build the library for
+// your use.
+
+use {
+    anyhow::{Context, Result},
+    std::process,
+};
+
+/// A `Command` that also knows its name.
+struct Command {
+    name: String,
+    rep: process::Command,
+}
+
+impl Command {
+    /// Creates a new command to run, with the executable `name`.
+    pub fn new(name: &'static str) -> Self {
+        let rep = process::Command::new(&name);
+        let name = String::from(name);
+        Command { name, rep }
+    }
+
+    /// Runs this command with `args` as arguments.
+    pub fn run(&mut self, args: &[&str]) -> Result<String> {
+        self.rep.args(args);
+        let stdout = self.stdout()?;
+        Ok(String::from(&stdout).trim().to_string())
+    }
+
+    // Captures the stdout of the command.
+    fn stdout(&mut self) -> Result<String> {
+        let output = self
+            .rep
+            .output()
+            .with_context(|| format!("could not execute command: {}", self.name))?;
+        let result = String::from_utf8(output.stdout)
+            .with_context(|| format!("could not convert output to UTF8"))?;
+        Ok(result.trim().to_string())
+    }
+}
+
+/// A command representing an auto-configuration detector.  Use `ICUConfig::new()` to create.
+struct ICUConfig {
+    rep: Command,
+}
+
+impl ICUConfig {
+    /// Creates a new ICUConfig.
+    fn new() -> Self {
+        ICUConfig {
+            rep: Command::new("pkg-config"),
+        }
+    }
+    /// Obtains the major-minor version number for the library. Returns a string like `64.2`.
+    fn version(&mut self) -> Result<String> {
+        self.rep
+            .run(&["--modversion", "icu-i18n"])
+            .with_context(|| format!("while getting ICU version; is icu-config in $PATH?"))
+    }
+
+    /// Returns the config major number.  For example, will return "64" for
+    /// version "64.2"
+    fn version_major() -> Result<String> {
+        let version = ICUConfig::new().version()?;
+        let components = version.split(".");
+        let last = components
+            .take(1)
+            .last()
+            .with_context(|| format!("could not parse version number: {}", version))?;
+        Ok(last.to_string())
+    }
+    
+    fn version_major_int() -> Result<i32> {
+        let version_str = ICUConfig::version_major()?;
+        Ok(version_str.parse().unwrap())
+    }
+}
+
+fn main() -> Result<()> {
+    std::env::set_var("RUST_BACKTRACE", "full");
+    let icu_major_version = ICUConfig::version_major_int()?;
+    println!("icu-major-version: {}", icu_major_version);
+    if icu_major_version >= 64 {
+        println!("cargo:rustc-cfg=features=\"icu_version_64_plus\"");
+    }
+    if icu_major_version >= 67 {
+        println!("cargo:rustc-cfg=features=\"icu_version_67_plus\"");
+    }
+    println!("done");
+    Ok(())
+}


### PR DESCRIPTION
With the following changes, we should be well positioned to tackle
ICU 67.1

- ICU4C correctly implements language fallbacks starting version 67.1,
  added two flavors of the same test, one for ICU versions 67 and
  onwards, and another for older versions.  Feature:
  `icu_version_67_plus`.  This happens in issue #59.
- ICU4C version 63 has wrong result for a certain test, possibly due to
  the CLDR version on my machine, so test failed.  Turned that test off
  for versions less than 64.  This happens on my machine only, when the
  system ICU is used.

See also issue #76 for where this is going to start being used.