### PR TITLE
Adds the build and test environments for ICU 67

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -44,6 +44,8 @@ all: \
 	push-testenv-65 \
 	push-maint-66 \
 	push-testenv-66 \
+	push-maint-67 \
+	push-testenv-67 \
 	push-testenv \
 	push-hermetic
 	echo "buildenv-version: ${VERSION}"


### PR DESCRIPTION
Since ICU 67 has been released, we can start testing for it.  This adds
the facility to build and push ICU 67.

The images will be built and pushed once this makes it into master.

See issue #76.