### PR TITLE
Add aliases in the proper crates for methods implemented in `uenum`

### DIFF
--- a/coverage/report.md
+++ b/coverage/report.md
@@ -2,7 +2,7 @@
 
 | Header | Implemented |
 | ------ | ----------- |
-| `ucal.h` | 12 / 46 | 
+| `ucal.h` | 15 / 46 | 
 | `udat.h` | 6 / 38 | 
 | `udata.h` | 2 / 8 | 
 | `uenum.h` | 8 / 8 | 
@@ -26,6 +26,9 @@
 | | `ucal_getTZDataVersion` |
 | | `ucal_inDaylightTime` |
 | | `ucal_open` |
+| | `ucal_openCountryTimeZones` |
+| | `ucal_openTimeZoneIDEnumeration` |
+| | `ucal_openTimeZones` |
 | | `ucal_setDate` |
 | | `ucal_setDateTime` |
 | | `ucal_setDefaultTimeZone` |
@@ -56,9 +59,6 @@
 | `ucal_getWindowsTimeZoneID` | |
 | `ucal_isSet` | |
 | `ucal_isWeekend` | |
-| `ucal_openCountryTimeZones` | |
-| `ucal_openTimeZoneIDEnumeration` | |
-| `ucal_openTimeZones` | |
 | `ucal_roll` | |
 | `ucal_set` | |
 | `ucal_setAttribute` | |
@@ -128,7 +128,7 @@
 | Unimplemented | Implemented |
 | ------------- | ----------- |
 | | `ucal_openCountryTimeZones` |
-| | `ucal_openTimeZoneIDENumeration` |
+| | `ucal_openTimeZoneIDEnumeration` |
 | | `ucal_openTimeZones` |
 | | `uenum_close` |
 | | `UEnumeration` |

--- a/coverage/ucal_implemented.txt
+++ b/coverage/ucal_implemented.txt
@@ -6,6 +6,9 @@ ucal_getNow
 ucal_getTZDataVersion
 ucal_inDaylightTime
 ucal_open
+ucal_openCountryTimeZones
+ucal_openTimeZoneIDEnumeration
+ucal_openTimeZones
 ucal_setDate
 ucal_setDateTime
 ucal_setDefaultTimeZone

--- a/coverage/uenum_implemented.txt
+++ b/coverage/uenum_implemented.txt
@@ -1,5 +1,5 @@
 ucal_openCountryTimeZones
-ucal_openTimeZoneIDENumeration
+ucal_openTimeZoneIDEnumeration
 ucal_openTimeZones
 uenum_close
 UEnumeration

--- a/rust_icu_uloc/build.rs
+++ b/rust_icu_uloc/build.rs
@@ -87,7 +87,7 @@ impl ICUConfig {
             .with_context(|| format!("could not parse version number: {}", version))?;
         Ok(last.to_string())
     }
-    
+
     fn version_major_int() -> Result<i32> {
         let version_str = ICUConfig::version_major()?;
         Ok(version_str.parse().unwrap())

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -591,7 +591,12 @@ mod tests {
     #[test]
     fn test_variant() -> Result<(), Error> {
         let loc = ULoc::try_from("zh-Latn-pinyin")?;
-        assert_eq!(loc.variant(), Some("PINYIN".to_string()), "locale was: {:?}", loc);
+        assert_eq!(
+            loc.variant(),
+            Some("PINYIN".to_string()),
+            "locale was: {:?}",
+            loc
+        );
         Ok(())
     }
 


### PR DESCRIPTION
- Add aliases for `uloc` and `ucal` methods that must be kept in `uenum`.
- Mark the versions in `uenum` as `#[doc(hidden)]`.
- Change wrapper of `ucal_openTimeZoneIDEnumeration` to support omitting the region. Add tests.

This CL contains breaking API changes and will require incrementing the minor version.

Fixes #80. 