### PR TITLE
Removes circular dev dependency ucal(dev)->udat->ucal

### DIFF
--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -58,10 +58,6 @@ icu_version_in_env = [
 icu_version_64_plus = []
 icu_version_67_plus = []
 
-[build-dependencies]
-anyhow = "1.0"
-bindgen = "0.53.2"
-
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "google/rust_icu" }


### PR DESCRIPTION
This change moves a few `ucal` tests up the test hierarchy
to remove a dev dependency of ucal onto udat.  This circular
dependency makes crates.io object to the dependency structure,
even though strictly speaking a dev dependency shouldn't count.

See issue #96 for a discussion of options.  I think this is the
least invasive change that we can make to keep the tests in their
current form.

Fixes: #96