### PR TITLE
Removes copy-pastaed build deps from Cargo.toml

### DIFF
--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -58,10 +58,6 @@ icu_version_in_env = [
 icu_version_64_plus = []
 icu_version_67_plus = []
 
-[build-dependencies]
-anyhow = "1.0"
-bindgen = "0.53.2"
-
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "google/rust_icu" }


### PR DESCRIPTION
Build dependencies are only relevant for build.rs, which
is not used in the 'ucol' crate.  They made it into this Cargo.toml
because I had used an existing one as a template and didn't
clean it up properly.