### PR TITLE
Make bindgen an optional build-dependency

### DIFF
--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -22,7 +22,7 @@ paste = "0.1.5"
 
 [build-dependencies]
 anyhow = "1.0"
-bindgen = "0.53.2"
+bindgen = { version = "0.53.2", optional = true }
 lazy_static = "1.4"
 
 [lib]
@@ -34,7 +34,7 @@ doctest = false
 # of these features.
 [features]
 default = ["use-bindgen", "renaming", "icu_config"]
-use-bindgen = []
+use-bindgen = ["bindgen"]
 renaming = []
 icu_config = []
 icu_version_in_env = []


### PR DESCRIPTION
This should prevent `bindgen` and its transitive dependencies from being pulled in for non-`bindgen` builds.