### PR TITLE
Increases the publish timeout to 30s from 5s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ clean:
 # not found by cargo immediately after a publish.  Sleeping on this is bad,
 # but there doesn't seem to be a much better option available.
 define publish
-	( cd $(1) && cargo publish && sleep 5)
+	( cd $(1) && cargo publish && sleep 30)
 endef
 
 # This is not the best method, since it will error out if a crate has already


### PR DESCRIPTION
Empirically I noticed that 30s of pause after an upload
is enough for followup uploads to be able to see previously
uploaded code.

Since I prefer to fire a `make publish` and forget over babysitting
the process, I'd opt for the increased timeout.