### PR TITLE
Increases the publish timeout to 30s from 5s

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: rust_icu default feature set
+name: Test
 on:
   push:
     branches: [ master ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "rust_icu_udat",
   "rust_icu_udata",
   "rust_icu_uenum",
+  "rust_icu_ulistformatter",
   "rust_icu_uloc",
   "rust_icu_umsg",
   "rust_icu_ustring",

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ clean:
 # not found by cargo immediately after a publish.  Sleeping on this is bad,
 # but there doesn't seem to be a much better option available.
 define publish
-	( cd $(1) && cargo publish && sleep 5)
+	( cd $(1) && cargo publish && sleep 30)
 endef
 
 # This is not the best method, since it will error out if a crate has already

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Item | Description |
 | ---- | ----------- |
-| ICU 64..67 | [![Build Status `master`](https://travis-ci.org/google/rust_icu.svg?branch=master)](https://travis-ci.org/google/rust_icu) |
+| ICU 64..67 | [![Test status](https://github.com/google/rust_icu/workflows/Test/badge.svg)](https://github.com/google/rust_icu/workflows/Test/badge.svg) |
 | Source | https://github.com/google/rust_icu |
 | README | https://github.com/google/rust_icu/blob/master/README.md |
 | Coverage | [View report](/coverage/report.md)
@@ -48,6 +48,7 @@ coverage in the headers.
 | [rust_icu](https://crates.io/crates/rust_icu)| Top-level crate.  Include this if you just want to have all the functionality available for use. |
 | [rust_icu_common](https://crates.io/crates/rust_icu_common)| Commonly used low-level wrappings of the bindings. |
 | [rust_icu_intl](https://crates.io/crates/rust_icu_intl)| Implements ECMA 402 recommendation APIs. |
+| [rust_icu_ulistformatter](https://crates.io/crates/rust_icu_ulistformatter)| Locale-sensitive list formatting support. Implements [`ulistformatter.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ulistformatter_8h.html) C API header from the ICU library. |
 | [rust_icu_sys](https://crates.io/crates/rust_icu_sys)| Low-level bindings code |
 | [rust_icu_ucal](https://crates.io/crates/rust_icu_ucal)| ICU Calendar. Implements [`ucal.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ucal_8h.html) C API header from the ICU library. |
 | [rust_icu_ucol](https://crates.io/crates/rust_icu_ucol)| Collation support. Implements [`ucol.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ucol_8h.html) C API header from the ICU library. |

--- a/rust_icu_sys/bindgen/run_bindgen.sh
+++ b/rust_icu_sys/bindgen/run_bindgen.sh
@@ -34,15 +34,16 @@ OUTPUT_DIR=${OUTPUT_DIR:-.}
 # build.rs file.
 readonly BINDGEN_SOURCE_MODULES=(
         "ucal"
+        "uclean"
+        "ucol"
         "udat"
         "udata"
         "uenum"
+        "ulistformatter"
+        "umsg"
+        "uset"
         "ustring"
         "utext"
-        "uclean"
-        "umsg"
-        "ucol"
-        "uset"
 )
 
 # Types for which to generate the bindings.  Expand this list if you need more.
@@ -53,18 +54,20 @@ readonly BINDGEN_ALLOWLIST_TYPES=(
         "UBool"
         "UCalendar.*"
         "UChar.*"
+        "UCol.*"
+        "UCollation.*"
+        "UCollator"
         "UData.*"
         "UDate.*"
         "UDateFormat.*"
         "UEnumeration.*"
         "UErrorCode"
+        "UFormattedList.*"
+        "UListFormatter.*"
         "UMessageFormat"
         "UParseError"
-        "UText"
-        "UCollator"
-        "UCollation.*"
         "USet"
-        "UCol.*"
+        "UText"
 )
 
 # Functions for which to generate the bindings.  Expand this list if you need
@@ -73,13 +76,14 @@ readonly BINDGEN_ALLOWLIST_TYPES=(
 readonly BINDGEN_ALLOWLIST_FUNCTIONS=(
         "u_.*"
         "ucal_.*"
-        "udata_.*"
-        "udat_.*"
-        "uenum_.*"
-        "uloc_.*"
-        "utext_.*"
-        "umsg_.*"
         "ucol_.*"
+        "udat_.*"
+        "udata_.*"
+        "uenum_.*"
+        "ulistfmt_.*"
+        "uloc_.*"
+        "umsg_.*"
+        "utext_.*"
 )
 
 function check_requirements() {

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -38,8 +38,17 @@ mod inner {
         // should be topologicaly sorted based on the inclusion relationship between the respective
         // headers.  Any of these will fail if the required binaries are not present in $PATH.
         static ref BINDGEN_SOURCE_MODULES: Vec<&'static str> = vec![
-            "ucal", "udat", "udata", "uenum", "ustring", "utext", "uclean", "umsg",
-            "ucol", "uset",
+            "ucal",
+            "uclean",
+            "ucol",
+            "udat",
+            "udata",
+            "uenum",
+            "ulistformatter",
+            "umsg",
+            "uset",
+            "ustring",
+            "utext",
         ];
 
         // C functions that will be made available to rust code.  Add more to this list if you want to
@@ -47,13 +56,14 @@ mod inner {
         static ref BINDGEN_ALLOWLIST_FUNCTIONS: Vec<&'static str> = vec![
             "u_.*",
             "ucal_.*",
-            "udata_.*",
-            "udat_.*",
-            "uenum_.*",
-            "uloc_.*",
-            "utext_.*",
-            "umsg_.*",
             "ucol_.*",
+            "udat_.*",
+            "udata_.*",
+            "uenum_.*",
+            "ulistfmt_.*",
+            "uloc_.*",
+            "umsg_.*",
+            "utext_.*",
         ];
 
         // C types that will be made available to rust code.  Add more to this list if you want to
@@ -63,18 +73,20 @@ mod inner {
             "UBool",
             "UCalendar.*",
             "UChar.*",
+            "UCol.*",
+            "UCollation.*",
+            "UCollator",
             "UData.*",
             "UDate.*",
             "UDateFormat.*",
             "UEnumeration.*",
             "UErrorCode",
+            "UFormattedList.*",
+            "UListFormatter.*",
             "UMessageFormat",
             "UParseError",
-            "UCollation.*",
-            "UCollator",
             "USet",
             "UText",
-            "UCol.*",
         ];
     }
 

--- a/rust_icu_ucol/src/lib.rs
+++ b/rust_icu_ucol/src/lib.rs
@@ -25,7 +25,7 @@
 //! reader can check out the [collation documentation on the ICU user
 //! guide](http://userguide.icu-project.org/collation).
 //!
-//! Are you missing some features from this crate?  Consider [reporting an
+//! > Are you missing some features from this crate?  Consider [reporting an
 //! issue](https://github.com/google/rust_icu/issues) or even [contributing the
 //! functionality](https://github.com/google/rust_icu/pulls).
 //!

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+authors = ["Google Inc."]
+edition = "2018"
+license = "Apache-2.0"
+name = "rust_icu_ulistformatter"
+readme = "README.md"
+repository = "https://github.com/google/rust_icu"
+version = "0.2.3"
+default-features = false
+keywords = ["icu", "unicode", "i18n", "l10n"]
+
+description = """
+Native bindings to the ICU4C library from Unicode.
+
+- ulistformatter.h: Collation support
+"""
+
+[dependencies]
+log = "0.4.6"
+paste = "0.1.5"
+rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
+#rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.2.3", default-features = false }
+anyhow = "1.0.25"
+
+[dev-dependencies]
+anyhow = "1.0.25"
+
+# See the feature description in ../rust_icu_sys/Cargo.toml for details.
+[features]
+default = ["use-bindgen", "renaming", "icu_config"]
+
+use-bindgen = [
+  "rust_icu_common/use-bindgen",
+  "rust_icu_sys/use-bindgen",
+  "rust_icu_ustring/use-bindgen",
+]
+renaming = [
+  "rust_icu_common/renaming",
+  "rust_icu_sys/renaming",
+  "rust_icu_ustring/renaming",
+]
+icu_config = [
+  "rust_icu_common/icu_config",
+  "rust_icu_sys/icu_config",
+  "rust_icu_ustring/icu_config",
+]
+icu_version_in_env = [
+  "rust_icu_common/icu_version_in_env",
+  "rust_icu_sys/icu_version_in_env",
+  "rust_icu_ustring/icu_version_in_env",
+]
+icu_version_64_plus = []
+icu_version_67_plus = []
+
+[badges]
+maintenance = { status = "actively-developed" }
+is-it-maintained-issue-resolution = { repository = "google/rust_icu" }
+is-it-maintained-open-issues = { repository = "google/rust_icu" }
+travis-ci = { repository = "google/rust_icu", branch = "master" }

--- a/rust_icu_ulistformatter/README.md
+++ b/rust_icu_ulistformatter/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/rust_icu_ulistformatter/src/lib.rs
+++ b/rust_icu_ulistformatter/src/lib.rs
@@ -1,0 +1,306 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # ICU list formatting support for rust
+//!
+//! This crate provides locale-sensitive list formatting, based on the list
+//! formatting as implemente by the ICU library.  Specifically, the functionality
+//! exposed through its C API, as available in the [header `ulisetformatter.h`][header].
+//!
+//!   [header]: https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ulistformatter_8h.html
+//!
+//! > Are you missing some features from this crate?  Consider [reporting an
+//! issue](https://github.com/google/rust_icu/issues) or even [contributing the
+//! functionality](https://github.com/google/rust_icu/pulls).
+//!
+//! ## Examples
+//!
+//! > TBD
+
+use {
+    rust_icu_common as common, rust_icu_sys as sys,
+    rust_icu_sys::versioned_function,
+    rust_icu_sys::*,
+    rust_icu_ustring as ustring,
+    std::{convert::TryFrom, convert::TryInto, ffi, ptr},
+};
+
+#[derive(Debug)]
+pub struct UListFormatter {
+    rep: ptr::NonNull<sys::UListFormatter>,
+}
+
+impl Drop for UListFormatter {
+    /// Implements ulistfmt_close`.
+    fn drop(&mut self) {
+        unsafe { versioned_function!(ulistfmt_close)(self.rep.as_ptr()) };
+    }
+}
+
+impl UListFormatter {
+    /// Implements ulistfmt_open`.
+    pub fn try_new(locale: &str) -> Result<UListFormatter, common::Error> {
+        let locale_cstr = ffi::CString::new(locale)?;
+        let mut status = common::Error::OK_CODE;
+        // Unsafety note: this is the way to create the formatter.  We expect all
+        // the passed-in values to be well-formed.
+        let rep = unsafe {
+            assert!(common::Error::is_ok(status));
+            versioned_function!(ulistfmt_open)(locale_cstr.as_ptr(), &mut status)
+                as *mut sys::UListFormatter
+        };
+        common::Error::ok_or_warning(status)?;
+        Ok(UListFormatter {
+            rep: ptr::NonNull::new(rep).unwrap(),
+        })
+    }
+
+    /// Implements `ulistfmt_openForType`.  Since ICU 67.
+    #[cfg(features = "icu_version_67_plus")]
+    pub fn try_new_styled(
+        locale: &str,
+        format_type: sys::UListFormatterType,
+        format_width: sys::UListFormatterWidth,
+    ) -> Result<UListFormatter, common::Error> {
+        let locale_cstr = ffi::CString::new(locale)?;
+        let mut status = common::Error::OK_CODE;
+        // Unsafety note: this is the way to create the formatter.  We expect all
+        // the passed-in values to be well-formed.
+        let rep = unsafe {
+            assert!(common::Error::is_ok(status));
+            versioned_function!(ulistfmt_openForType)(
+                locale_cstr.as_ptr(),
+                format_type,
+                format_width,
+                &mut status,
+            ) as *mut sys::UListFormatter
+        };
+        common::Error::ok_or_warning(status)?;
+        Ok(UListFormatter {
+            rep: ptr::NonNull::new(rep).unwrap(),
+        })
+    }
+
+    /// Implements `ulistfmt_format`.
+    pub fn format(&self, list: &[&str]) -> Result<String, common::Error> {
+        let result = self.format_uchar(list)?;
+        String::try_from(&result)
+    }
+
+    /// Implements `ulistfmt_format`.
+    pub fn format_uchar(&self, list: &[&str]) -> Result<ustring::UChar, common::Error> {
+        let list_ustr = UCharArray::try_from(list)?;
+        const CAPACITY: usize = 200;
+        let (pointers, strlens, len) = unsafe { list_ustr.as_pascal_strings() };
+
+        // This is similar to buffered_string_method_with_retry, except the buffer
+        // consists of [sys::UChar]s.
+        let mut status = common::Error::OK_CODE;
+        let mut buf: Vec<sys::UChar> = vec![0; CAPACITY];
+
+        let full_len: i32 = unsafe {
+            assert!(common::Error::is_ok(status));
+            versioned_function!(ulistfmt_format)(
+                self.rep.as_ptr(),
+                pointers as *const *const sys::UChar,
+                strlens as *const i32,
+                len as i32,
+                buf.as_mut_ptr(),
+                CAPACITY as i32,
+                &mut status,
+            )
+        };
+        if status == sys::UErrorCode::U_BUFFER_OVERFLOW_ERROR
+            || (common::Error::is_ok(status)
+                && full_len > CAPACITY.try_into().map_err(|e| common::Error::wrapper(e))?)
+        {
+            assert!(full_len > 0);
+            let full_len: usize = full_len.try_into().map_err(|e| common::Error::wrapper(e))?;
+            buf.resize(full_len, 0);
+            unsafe {
+                assert!(common::Error::is_ok(status));
+                versioned_function!(ulistfmt_format)(
+                    self.rep.as_ptr(),
+                    pointers as *const *const sys::UChar,
+                    strlens as *const i32,
+                    len as i32,
+                    buf.as_mut_ptr(),
+                    buf.len() as i32,
+                    &mut status,
+                )
+            };
+        }
+        common::Error::ok_or_warning(status)?;
+        if full_len >= 0 {
+            let full_len: usize = full_len.try_into().map_err(|e| common::Error::wrapper(e))?;
+            buf.resize(full_len, 0);
+        }
+        Ok(ustring::UChar::from(buf))
+    }
+}
+
+/// A helper array that deconstructs [ustring::UChar] into constituent raw parts
+/// that can be passed into formatting functions that use array APIs for parameter-passing.
+///
+/// Create with [UCharArray::try_from], and then use [UCharArray::as_pascal_strings] to get
+/// the respective sizes.
+#[derive(Debug)]
+struct UCharArray {
+    // The elements of the array.
+    elements: Vec<ustring::UChar>,
+    // Pointers to the respective elements.
+    pointers: Vec<*const sys::UChar>,
+    // The string lengths (in ustring::UChar units) of respective elements.
+    // These strlens are what `listfmt_format` expects, so can't be `usize` but
+    // *must* be `i32`.
+    strlens: Vec<i32>,
+}
+
+impl<T> TryFrom<&[T]> for UCharArray
+where
+    T: AsRef<str>,
+{
+    type Error = common::Error;
+
+    /// Creates a new [UCharArray] from an array of string-like types.
+    fn try_from(list: &[T]) -> Result<Self, Self::Error> {
+        let mut elements: Vec<ustring::UChar> = Vec::with_capacity(list.len());
+        for element in list {
+            let uchar = ustring::UChar::try_from(element.as_ref())?;
+            elements.push(uchar);
+        }
+        let pointers = elements.iter().map(|e| e.as_c_ptr()).collect();
+        let strlens = elements.iter().map(|e| e.len() as i32).collect();
+        Ok(UCharArray {
+            elements,
+            pointers,
+            strlens,
+        })
+    }
+}
+
+impl AsRef<Vec<ustring::UChar>> for UCharArray {
+    fn as_ref(&self) -> &Vec<ustring::UChar> {
+        &self.elements
+    }
+}
+
+impl UCharArray {
+    /// Returns the elements of the array decomposed as "pascal strings", i.e.
+    /// separating out the pointers, the sizes of each individual string included,
+    /// and the total size of the array.
+    pub unsafe fn as_pascal_strings(self) -> (*mut *mut sys::UChar, *mut *mut i32, usize) {
+        let pointers = self.pointers.as_ptr() as *mut *mut sys::UChar;
+        let strlens = self.strlens.as_ptr() as *mut *mut i32;
+        let len = self.elements.len();
+        // Since 'self' was not moved anywhere in this method, we need to forget it before we
+        // return pointers to its content, else all the pointers will be invalidated.
+        std::mem::forget(self);
+        (pointers, strlens, len)
+    }
+
+    /// Returns the number of elements in the array.
+    #[allow(dead_code)] // Not used in production code yet.
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Assembles an [UCharArray] from parts (ostensibly, obtained through
+    /// [UCharArray::as_pascal_strings] above.  Unsafe, as there is no guarantee
+    /// that the pointers are well-formed.
+    ///
+    /// Takes ownership away from the pointers and strlens.  Requires that
+    /// `len` is equal to the capacities and lengths of the vectors described by
+    /// `pointers` and `strlens`.
+    #[allow(dead_code)]
+    pub unsafe fn from_raw_parts(
+        pointers: *mut *mut sys::UChar,
+        strlens: *mut *mut i32,
+        len: usize,
+    ) -> UCharArray {
+        let pointers_vec: Vec<*mut sys::UChar> = Vec::from_raw_parts(pointers, len, len);
+        let strlens_vec: Vec<i32> = Vec::from_raw_parts(strlens as *mut i32, len, len);
+
+        let elements = pointers_vec.into_iter().zip(strlens_vec);
+        let elements = elements
+            .map(|(ptr, len): (*mut sys::UChar, i32)| {
+                assert!(len >= 0);
+                let len_i32 = len as usize;
+                let raw: Vec<sys::UChar> = Vec::from_raw_parts(ptr, len_i32, len_i32);
+                ustring::UChar::from(raw)
+            })
+            .collect::<Vec<ustring::UChar>>();
+        let pointers = elements.iter().map(|e| e.as_c_ptr()).collect();
+        let strlens = elements.iter().map(|e| e.len() as i32).collect();
+
+        UCharArray {
+            elements,
+            pointers,
+            strlens,
+        }
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use crate::*;
+
+    #[test]
+    fn test_pascal_strings() {
+        let array = UCharArray::try_from(&["eenie", "meenie", "minie", "moe"][..])
+            .expect("created with success");
+        let array_len = array.len();
+        println!("blah");
+        let (strings, strlens, len) = unsafe { array.as_pascal_strings() };
+        assert_eq!(len, array_len);
+
+        let reconstructed = unsafe { UCharArray::from_raw_parts(strings, strlens, len) };
+        let result = reconstructed
+            .as_ref()
+            .iter()
+            .map(|e| String::try_from(e).expect("conversion is a success"))
+            .collect::<Vec<String>>();
+        assert_eq!(vec!["eenie", "meenie", "minie", "moe"], result);
+    }
+
+    #[test]
+    fn test_formatting() {
+        let array = ["eenie", "meenie", "minie", "moe"];
+        let formatter = crate::UListFormatter::try_new("en-US").expect("has list format");
+        let result = formatter.format(&array).expect("formatting succeeds");
+        assert_eq!("eenie, meenie, minie, and moe", result);
+    }
+
+    #[test]
+    fn test_formatting_sr() {
+        let array = ["Раја", "Гаја", "Влаја"]; // Huey, Dewey, and Louie.
+        let formatter = crate::UListFormatter::try_new("sr-RS").expect("has list format");
+        let result = formatter.format(&array).expect("formatting succeeds");
+        assert_eq!("Раја, Гаја и Влаја", result);
+    }
+
+    #[cfg(features = "icu_version_67_plus")]
+    #[test]
+    fn test_formatting_styled() {
+        let array = ["Раја", "Гаја", "Влаја"]; // Hewey, Dewey, and Louie.
+        let formatter = crate::UListFormatter::try_new_styled(
+            "sr-RS",
+            sys: UListFormatterType::ULISTFMT_TYPE_OR,
+            sys::UListFormatterWidth::ULISTFMT_WIDTH_WIDE,
+        )
+        .expect("has list format");
+        let result = formatter.format(&array).expect("formatting succeeds");
+        assert_eq!("Раја, Гаја или Влаја", result);
+    }
+}

--- a/rust_icu_ustring/src/lib.rs
+++ b/rust_icu_ustring/src/lib.rs
@@ -155,6 +155,13 @@ impl TryFrom<&UChar> for String {
     }
 }
 
+impl From<Vec<sys::UChar>> for crate::UChar {
+    /// Adopts a vector of [sys::UChar] into a string.
+    fn from(rep: Vec<sys::UChar>) -> crate::UChar {
+        crate::UChar { rep }
+    }
+}
+
 impl crate::UChar {
     /// Allocates a new UChar with given capacity.
     ///
@@ -162,7 +169,7 @@ impl crate::UChar {
     /// low-level code.
     pub fn new_with_capacity(capacity: usize) -> crate::UChar {
         let rep: Vec<sys::UChar> = vec![0; capacity];
-        crate::UChar { rep: rep }
+        crate::UChar::from(rep)
     }
 
     /// Converts into a zeroed-out string.


### PR DESCRIPTION
Empirically I noticed that 30s of pause after an upload
is enough for followup uploads to be able to see previously
uploaded code.

Since I prefer to fire a `make publish` and forget over babysitting
the process, I'd opt for the increased timeout.

Fixed: #115