### PR TITLE
Start using buildenv 1.1.0

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,8 @@
+# These flags are the only way to tell cargo to add directories to the library
+# search path.  When `build.rs` script is used, this is not needed since the
+# script will set the library paths correctly.  But when it isn't used,
+# something still needs to produce these flags.  With cargo, this is the only
+# way.
+[build]
+rustflags=["-L", "/usr/local/lib"]
+rustdocflags=["-L", "/usr/local/lib"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        icu_version: [63, 64, 65, 67]
-        feature_set: ["renaming,icu_version_in_env"]
+        icu_version: [63]
+        feature_set: 
+          - "renaming,icu_version_in_env"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}
@@ -30,7 +31,9 @@ jobs:
     strategy:
       matrix:
         icu_version: [64, 65]
-        feature_set: ["renaming,icu_version_in_env,icu_version_64_plus"]
+        feature_set: 
+          - "renaming,icu_version_in_env,icu_version_64_plus"
+          - "renaming,icu_version_64_plus,icu_config,use-bindgen"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}
@@ -40,7 +43,9 @@ jobs:
     strategy:
       matrix:
         icu_version: [67]
-        feature_set: ["renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus"]
+        feature_set: 
+          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus"
+          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_config,use-bindgen"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 #   make USED_BUILDENV_VERSION=whatever-you-want docker-test
 #
 # NOTE: This version number is completely independent of the crate version.
-USED_BUILDENV_VERSION ?= 1.0.0
+USED_BUILDENV_VERSION ?= 1.1.0
 
 CARGO_FEATURE_VERSION :=
 


### PR DESCRIPTION
Buildenv 1.1.0 is hopefully upgraded to do *correct* feature testing.
The answer here seems to be "yes, it's correct", based on spot-checks.

One more issue came up while I was probing: the builds that didn't use
the build script didn't get the appropriate `-L` flag added to the
linker command, and would therefore fail.  I added the .cargo/config
file for that.  While in theory these settings could clash with those
produced by the build.rs, I think in practice this will likely be rare. (You'd
need to have a conflicting version of ICU in /usr/local/lib *and* elsewhere.)

As result, I also restructured the test workflows:
- Broke the tests apart into subsets - now all ICU versions 64 and up
  are tested with the flag icu_version_64_plus.
- Removed incompatible flag combinations: `use_bindgen` is incompatible
  with `icu_version_in_env`.

Closes #120.