### PR TITLE
Uprev to a version 0.3.0 of rust_icu.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ publish:
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
 UPREV_OLD_VERSION ?= 0.2.3
-UPREV_NEW_VERSION ?= 0.2.4
+UPREV_NEW_VERSION ?= 0.3.0
 define uprev
 	( \
 		cd $(1) && \

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,18 +18,18 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.2.3", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "0.2.3", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "0.2.3", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "0.2.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.2.3", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.2.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.2.3", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.2.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.2.3", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.0", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "0.3.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "0.3.0", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "0.3.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.3.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.3.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "0.3.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.2.3", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.2.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.3.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.2.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.2.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.2.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.2.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.2.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
-#rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.2.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+#rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -19,10 +19,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.2.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.2.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.2.3", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.2.3"
+version = "0.3.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.2.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]


### PR DESCRIPTION
Changes below.

commit a602da147595cb1070607c7c5b20129adc987f02
Author: Didrik Nordström <dnordstrom@google.com>

    rust_icu_uloc: Make build.rs no-op if icu_config is disabled

commit 6fd6cc17031cbe2dba1e5f4035f3a2b01ca9795a
Author: Filip Filmar <fmil@google.com>

    Start using buildenv 1.1.0

commit a209f7e01430c29763d1e7d6fd6f2145591bee07
Author: Filip Filmar <fmil@google.com>

    A proposal for a minimal ECMA 402 API surface

commit 6859b7bf72715f9249c0e038be600be7d8bc59af
Author: Filip Filmar <fmil@google.com>

    Adds the intro README.md

commit 883b3ea5f9ee8f9d52daa43007a734a0dc48938b
Author: Filip Filmar <fmil@google.com>

    Fixes a number of mistakes in the feature setup

commit 355123bbdf04f211900b6f3da50a30925216c777
Author: Filip Filmar <fmil@google.com>

    After-the-fact trim-down of excess text

commit fb7c8b6180b47f4c2549ea4d264de36c2dda5a84
Author: Filip Filmar <fmil@google.com>

    Implements string list formatting

commit 321c06b08e7776c2ef3827b84cafb046e4c8336a
Author: Didrik Nordström <dnordstrom@google.com>

    Use std::os::raw::c_char instead of hardcoded i8

commit a6e650492f139e715b38daf9eb6546ec5cf57be4
Author: Filip Filmar <fmil@google.com>

    Increases the publish timeout to 30s from 5s