### PR TITLE
ICU upluralrules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "rust_icu_ulistformatter",
   "rust_icu_uloc",
   "rust_icu_umsg",
+  "rust_icu_upluralrules",
   "rust_icu_ustring",
   "rust_icu_utext",
 ]

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,8 @@ publish:
 # A helper to up-rev the cargo crate versions.
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
-UPREV_OLD_VERSION ?= 0.3.0
-UPREV_NEW_VERSION ?= 0.3.1
+UPREV_OLD_VERSION ?= 0.3.1
+UPREV_NEW_VERSION ?= 0.3.2
 define uprev
 	( \
 		cd $(1) && \

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ publish:
 	$(call publish,rust_icu_ucol)
 	$(call publish,rust_icu_umsg)
 	$(call publish,rust_icu_ulistformatter)
+	$(call publish,rust_icu_upluralrules)
 	$(call publish,rust_icu)
 
 # A helper to up-rev the cargo crate versions.
@@ -160,7 +161,7 @@ uprev:
 	$(call uprev,rust_icu_umsg)
 	$(call uprev,rust_icu_intl)
 	$(call uprev,rust_icu_ucol)
-	$(call uprev,rust_icu_ulistformatter)
+	$(call uprev,rust_icu_upluralrules)
 	$(call uprev,rust_icu)
 
 cov:

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,8 @@ publish:
 # A helper to up-rev the cargo crate versions.
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
-UPREV_OLD_VERSION ?= 0.2.3
-UPREV_NEW_VERSION ?= 0.3.0
+UPREV_OLD_VERSION ?= 0.3.0
+UPREV_NEW_VERSION ?= 0.3.1
 define uprev
 	( \
 		cd $(1) && \
@@ -149,20 +149,21 @@ endef
 
 .PHONY: uprev
 uprev:
-	$(call uprev,rust_icu_sys)
+	$(call uprev,rust_icu)
 	$(call uprev,rust_icu_common)
-	$(call uprev,rust_icu_uenum)
-	$(call uprev,rust_icu_ustring)
-	$(call uprev,rust_icu_utext)
-	$(call uprev,rust_icu_uloc)
+	$(call uprev,rust_icu_intl)
+	$(call uprev,rust_icu_sys)
 	$(call uprev,rust_icu_ucal)
+	$(call uprev,rust_icu_ucol)
 	$(call uprev,rust_icu_udat)
 	$(call uprev,rust_icu_udata)
+	$(call uprev,rust_icu_uenum)
+	$(call uprev,rust_icu_ulistformatter)
+	$(call uprev,rust_icu_uloc)
 	$(call uprev,rust_icu_umsg)
-	$(call uprev,rust_icu_intl)
-	$(call uprev,rust_icu_ucol)
 	$(call uprev,rust_icu_upluralrules)
-	$(call uprev,rust_icu)
+	$(call uprev,rust_icu_ustring)
+	$(call uprev,rust_icu_utext)
 
 cov:
 	./build/showprogress.sh

--- a/README.md
+++ b/README.md
@@ -48,15 +48,16 @@ coverage in the headers.
 | [rust_icu](https://crates.io/crates/rust_icu)| Top-level crate.  Include this if you just want to have all the functionality available for use. |
 | [rust_icu_common](https://crates.io/crates/rust_icu_common)| Commonly used low-level wrappings of the bindings. |
 | [rust_icu_intl](https://crates.io/crates/rust_icu_intl)| Implements ECMA 402 recommendation APIs. |
-| [rust_icu_ulistformatter](https://crates.io/crates/rust_icu_ulistformatter)| Locale-sensitive list formatting support. Implements [`ulistformatter.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ulistformatter_8h.html) C API header from the ICU library. |
 | [rust_icu_sys](https://crates.io/crates/rust_icu_sys)| Low-level bindings code |
 | [rust_icu_ucal](https://crates.io/crates/rust_icu_ucal)| ICU Calendar. Implements [`ucal.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ucal_8h.html) C API header from the ICU library. |
 | [rust_icu_ucol](https://crates.io/crates/rust_icu_ucol)| Collation support. Implements [`ucol.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ucol_8h.html) C API header from the ICU library. |
 | [rust_icu_udat](https://crates.io/crates/rust_icu_udat)| ICU date and time. Implements [`udat.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/udat_8h.html) C API header from the ICU library. |
 | [rust_icu_udata](https://crates.io/crates/rust_icu_udata)| ICU binary data. Implements [`udata.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/udata_8h.html) C API header from the ICU library. |
 | [rust_icu_uenum](https://crates.io/crates/rust_icu_uenum)| ICU enumerations. Implements [`uenum.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/uenum_8h.html) C API header from the ICU library. Mainly `UEnumeration` and friends. |
+| [rust_icu_ulistformatter](https://crates.io/crates/rust_icu_ulistformatter)| Locale-sensitive list formatting support. Implements [`ulistformatter.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ulistformatter_8h.html) C API header from the ICU library. |
 | [rust_icu_uloc](https://crates.io/crates/rust_icu_uloc)| Locale support. Implements [`uloc.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/uloc_8h.html) C API header from the ICU library. |
 | [rust_icu_umsg](https://crates.io/crates/rust_icu_umsg)| MessageFormat support. Implements [`umsg.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/umsg_8h.html) C API header from the ICU library. |
+| [rust_icu_upluralrules](https://crates.io/crates/rust_icu_upluralrules)| Locale-sensitive plural rules support. Implements [`upluralrules.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/upluralrules_8h.html) C API header from the ICU library. |
 | [rust_icu_ustring](https://crates.io/crates/rust_icu_ustring)| ICU strings. Implements [`ustring.h`]() C API header from the ICU library. |
 | [rust_icu_utext](https://crates.io/crates/rust_icu_utext)| Text operations. Implements [`utext.h`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/utext_8h.html) C API header from the ICU library. |
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ this particular ICU library and `rust_icu` version combination.
 | 0.2                | ☟        | ☟        | ☟         | ☟          | ☟        |
 | 0.2.2              | 1        | 1        | 1;2;2+3   | 1          | 1        |
 | 0.2.3              | 1;2;2+3  | 1;2;2+3  | 1;2;2+3   | 1;2;2+3    | 1;2;2+3  |
+| 0.3                | 1;2;2+3  | 1;2;2+3  | 1;2;2+3   | 1;2;2+3    | 1;2;2+3  |
+| 0.3.0              | 1;2;2+3  | 1;2;2+3  | 1;2;2+3   | 1;2;2+3    | 1;2;2+3  |
 
 > Prior to a 1.0.0 release, API versions that only differ in the patch version
 > number (0.x.**y**) only should be compatible.

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,18 +18,18 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.0", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "0.3.0", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "0.3.0", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "0.3.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.3.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.0", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.3.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.1", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "0.3.1", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "0.3.1", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "0.3.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.1", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.3.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.1", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.3.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "0.3.1", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.0", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.3.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.1", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.3.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_sys/bindgen/lib_63.rs
+++ b/rust_icu_sys/bindgen/lib_63.rs
@@ -3056,6 +3056,59 @@ extern "C" {
         ec: *mut UErrorCode,
     ) -> i32;
 }
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd)]
+pub enum UPluralType {
+    UPLURAL_TYPE_CARDINAL = 0,
+    UPLURAL_TYPE_ORDINAL = 1,
+    UPLURAL_TYPE_COUNT = 2,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UPluralRules {
+    _unused: [u8; 0],
+}
+extern "C" {
+    pub fn uplrules_open_63(
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UPluralRules;
+}
+extern "C" {
+    pub fn uplrules_openForType_63(
+        locale: *const ::std::os::raw::c_char,
+        type_: UPluralType,
+        status: *mut UErrorCode,
+    ) -> *mut UPluralRules;
+}
+extern "C" {
+    pub fn uplrules_close_63(uplrules: *mut UPluralRules);
+}
+extern "C" {
+    pub fn uplrules_select_63(
+        uplrules: *const UPluralRules,
+        number: f64,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_selectWithFormat_63(
+        uplrules: *const UPluralRules,
+        number: f64,
+        fmt: *const UNumberFormat,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_getKeywords_63(
+        uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
 extern "C" {
     pub fn u_getDataDirectory_63() -> *const ::std::os::raw::c_char;
 }

--- a/rust_icu_sys/bindgen/lib_64.rs
+++ b/rust_icu_sys/bindgen/lib_64.rs
@@ -3088,6 +3088,73 @@ extern "C" {
         ec: *mut UErrorCode,
     ) -> i32;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UFormattedNumber {
+    _unused: [u8; 0],
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd)]
+pub enum UPluralType {
+    UPLURAL_TYPE_CARDINAL = 0,
+    UPLURAL_TYPE_ORDINAL = 1,
+    UPLURAL_TYPE_COUNT = 2,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UPluralRules {
+    _unused: [u8; 0],
+}
+extern "C" {
+    pub fn uplrules_open_64(
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UPluralRules;
+}
+extern "C" {
+    pub fn uplrules_openForType_64(
+        locale: *const ::std::os::raw::c_char,
+        type_: UPluralType,
+        status: *mut UErrorCode,
+    ) -> *mut UPluralRules;
+}
+extern "C" {
+    pub fn uplrules_close_64(uplrules: *mut UPluralRules);
+}
+extern "C" {
+    pub fn uplrules_select_64(
+        uplrules: *const UPluralRules,
+        number: f64,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_selectFormatted_64(
+        uplrules: *const UPluralRules,
+        number: *const UFormattedNumber,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_selectWithFormat_64(
+        uplrules: *const UPluralRules,
+        number: f64,
+        fmt: *const UNumberFormat,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_getKeywords_64(
+        uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
 extern "C" {
     pub fn u_getDataDirectory_64() -> *const ::std::os::raw::c_char;
 }

--- a/rust_icu_sys/bindgen/lib_65.rs
+++ b/rust_icu_sys/bindgen/lib_65.rs
@@ -3109,6 +3109,73 @@ extern "C" {
         ec: *mut UErrorCode,
     ) -> i32;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UFormattedNumber {
+    _unused: [u8; 0],
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd)]
+pub enum UPluralType {
+    UPLURAL_TYPE_CARDINAL = 0,
+    UPLURAL_TYPE_ORDINAL = 1,
+    UPLURAL_TYPE_COUNT = 2,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UPluralRules {
+    _unused: [u8; 0],
+}
+extern "C" {
+    pub fn uplrules_open_65(
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UPluralRules;
+}
+extern "C" {
+    pub fn uplrules_openForType_65(
+        locale: *const ::std::os::raw::c_char,
+        type_: UPluralType,
+        status: *mut UErrorCode,
+    ) -> *mut UPluralRules;
+}
+extern "C" {
+    pub fn uplrules_close_65(uplrules: *mut UPluralRules);
+}
+extern "C" {
+    pub fn uplrules_select_65(
+        uplrules: *const UPluralRules,
+        number: f64,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_selectFormatted_65(
+        uplrules: *const UPluralRules,
+        number: *const UFormattedNumber,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_selectWithFormat_65(
+        uplrules: *const UPluralRules,
+        number: f64,
+        fmt: *const UNumberFormat,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_getKeywords_65(
+        uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
 extern "C" {
     pub fn u_getDataDirectory_65() -> *const ::std::os::raw::c_char;
 }

--- a/rust_icu_sys/bindgen/lib_66.rs
+++ b/rust_icu_sys/bindgen/lib_66.rs
@@ -3109,6 +3109,73 @@ extern "C" {
         ec: *mut UErrorCode,
     ) -> i32;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UFormattedNumber {
+    _unused: [u8; 0],
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd)]
+pub enum UPluralType {
+    UPLURAL_TYPE_CARDINAL = 0,
+    UPLURAL_TYPE_ORDINAL = 1,
+    UPLURAL_TYPE_COUNT = 2,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UPluralRules {
+    _unused: [u8; 0],
+}
+extern "C" {
+    pub fn uplrules_open_66(
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UPluralRules;
+}
+extern "C" {
+    pub fn uplrules_openForType_66(
+        locale: *const ::std::os::raw::c_char,
+        type_: UPluralType,
+        status: *mut UErrorCode,
+    ) -> *mut UPluralRules;
+}
+extern "C" {
+    pub fn uplrules_close_66(uplrules: *mut UPluralRules);
+}
+extern "C" {
+    pub fn uplrules_select_66(
+        uplrules: *const UPluralRules,
+        number: f64,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_selectFormatted_66(
+        uplrules: *const UPluralRules,
+        number: *const UFormattedNumber,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_selectWithFormat_66(
+        uplrules: *const UPluralRules,
+        number: f64,
+        fmt: *const UNumberFormat,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_getKeywords_66(
+        uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
 extern "C" {
     pub fn u_getDataDirectory_66() -> *const ::std::os::raw::c_char;
 }

--- a/rust_icu_sys/bindgen/lib_67.rs
+++ b/rust_icu_sys/bindgen/lib_67.rs
@@ -3139,6 +3139,73 @@ extern "C" {
         ec: *mut UErrorCode,
     ) -> i32;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UFormattedNumber {
+    _unused: [u8; 0],
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd)]
+pub enum UPluralType {
+    UPLURAL_TYPE_CARDINAL = 0,
+    UPLURAL_TYPE_ORDINAL = 1,
+    UPLURAL_TYPE_COUNT = 2,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UPluralRules {
+    _unused: [u8; 0],
+}
+extern "C" {
+    pub fn uplrules_open_67(
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UPluralRules;
+}
+extern "C" {
+    pub fn uplrules_openForType_67(
+        locale: *const ::std::os::raw::c_char,
+        type_: UPluralType,
+        status: *mut UErrorCode,
+    ) -> *mut UPluralRules;
+}
+extern "C" {
+    pub fn uplrules_close_67(uplrules: *mut UPluralRules);
+}
+extern "C" {
+    pub fn uplrules_select_67(
+        uplrules: *const UPluralRules,
+        number: f64,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_selectFormatted_67(
+        uplrules: *const UPluralRules,
+        number: *const UFormattedNumber,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_selectWithFormat_67(
+        uplrules: *const UPluralRules,
+        number: f64,
+        fmt: *const UNumberFormat,
+        keyword: *mut UChar,
+        capacity: i32,
+        status: *mut UErrorCode,
+    ) -> i32;
+}
+extern "C" {
+    pub fn uplrules_getKeywords_67(
+        uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
 extern "C" {
     pub fn u_getDataDirectory_67() -> *const ::std::os::raw::c_char;
 }

--- a/rust_icu_sys/bindgen/run_bindgen.sh
+++ b/rust_icu_sys/bindgen/run_bindgen.sh
@@ -41,6 +41,7 @@ readonly BINDGEN_SOURCE_MODULES=(
         "uenum"
         "ulistformatter"
         "umsg"
+        "upluralrules"
         "uset"
         "ustring"
         "utext"
@@ -66,6 +67,7 @@ readonly BINDGEN_ALLOWLIST_TYPES=(
         "UListFormatter.*"
         "UMessageFormat"
         "UParseError"
+        "UPlural.*"
         "USet"
         "UText"
 )
@@ -83,6 +85,7 @@ readonly BINDGEN_ALLOWLIST_FUNCTIONS=(
         "ulistfmt_.*"
         "uloc_.*"
         "umsg_.*"
+        "uplrules_.*"
         "utext_.*"
 )
 

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -46,6 +46,7 @@ mod inner {
             "uenum",
             "ulistformatter",
             "umsg",
+            "upluralrules",
             "uset",
             "ustring",
             "utext",
@@ -63,6 +64,7 @@ mod inner {
             "ulistfmt_.*",
             "uloc_.*",
             "umsg_.*",
+            "uplrules_.*",
             "utext_.*",
         ];
 
@@ -85,6 +87,7 @@ mod inner {
             "UListFormatter.*",
             "UMessageFormat",
             "UParseError",
+            "UPlural.*",
             "USet",
             "UText",
         ];

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/src/lib.rs
+++ b/rust_icu_uenum/src/lib.rs
@@ -122,6 +122,26 @@ impl Iterator for Enumeration {
     }
 }
 
+impl Enumeration {
+    /// Constructs an [Enumeration] from a raw pointer.
+    ///
+    /// **DO NOT USE THIS FUNCTION UNLESS THERE IS NO OTHER CHOICE!**
+    ///
+    /// We tried to keep this function hidden to avoid the
+    /// need to have a such a powerful unsafe function in the
+    /// public API.  It worked up to a point for free functions.
+    ///
+    /// It no longer works on high-level methods that return
+    /// enumerations, since they we'd need to depend on them to
+    /// create an [Enumeration].
+    pub unsafe fn from_raw_parts(
+        raw: Option<common::CStringVec>,
+        rep: *mut sys::UEnumeration,
+    ) -> Enumeration {
+        Enumeration { raw, rep }
+    }
+}
+
 #[doc(hidden)]
 /// Implements `ucal_openCountryTimeZones`.
 // This should be in the `ucal` crate, but not possible because of the raw enum initialization.

--- a/rust_icu_uenum/src/lib.rs
+++ b/rust_icu_uenum/src/lib.rs
@@ -132,8 +132,9 @@ impl Enumeration {
     /// public API.  It worked up to a point for free functions.
     ///
     /// It no longer works on high-level methods that return
-    /// enumerations, since they we'd need to depend on them to
+    /// enumerations, since then we'd need to depend on them to
     /// create an [Enumeration].
+    #[doc(hidden)]
     pub unsafe fn from_raw_parts(
         raw: Option<common::CStringVec>,
         rep: *mut sys::UEnumeration,

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,9 +18,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -19,10 +19,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
 ecma402_traits = { path = "../ecma402_traits", version = "0.1.0" }
 
 [dev-dependencies]

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -1,0 +1,75 @@
+[package]
+authors = ["Google Inc."]
+edition = "2018"
+license = "Apache-2.0"
+name = "rust_icu_upluralrules"
+readme = "README.md"
+repository = "https://github.com/google/rust_icu"
+version = "0.3.0"
+default-features = false
+keywords = ["icu", "unicode", "i18n", "l10n"]
+
+description = """
+Native bindings to the ICU4C library from Unicode.
+
+- ulistformatter.h: Collation support
+"""
+
+[dependencies]
+log = "0.4.6"
+paste = "0.1.5"
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
+anyhow = "1.0.25"
+
+[dev-dependencies]
+anyhow = "1.0.25"
+
+# See the feature description in ../rust_icu_sys/Cargo.toml for details.
+[features]
+default = ["use-bindgen", "renaming", "icu_config"]
+
+use-bindgen = [
+  "rust_icu_common/use-bindgen",
+  "rust_icu_sys/use-bindgen",
+  "rust_icu_uenum/use-bindgen",
+  "rust_icu_ustring/use-bindgen",
+]
+renaming = [
+  "rust_icu_common/renaming",
+  "rust_icu_sys/renaming",
+  "rust_icu_uenum/renaming",
+  "rust_icu_ustring/renaming",
+]
+icu_config = [
+  "rust_icu_common/icu_config",
+  "rust_icu_sys/icu_config",
+  "rust_icu_uenum/icu_config",
+  "rust_icu_ustring/icu_config",
+]
+icu_version_in_env = [
+  "rust_icu_common/icu_version_in_env",
+  "rust_icu_sys/icu_version_in_env",
+  "rust_icu_uenum/icu_version_in_env",
+  "rust_icu_ustring/icu_version_in_env",
+]
+icu_version_64_plus = [
+  "rust_icu_common/icu_version_64_plus",
+  "rust_icu_sys/icu_version_64_plus",
+  "rust_icu_uenum/icu_version_64_plus",
+  "rust_icu_ustring/icu_version_64_plus",
+]
+icu_version_67_plus = [
+  "rust_icu_common/icu_version_67_plus",
+  "rust_icu_sys/icu_version_67_plus",
+  "rust_icu_uenum/icu_version_67_plus",
+  "rust_icu_ustring/icu_version_67_plus",
+]
+
+[badges]
+maintenance = { status = "actively-developed" }
+is-it-maintained-issue-resolution = { repository = "google/rust_icu" }
+is-it-maintained-open-issues = { repository = "google/rust_icu" }
+travis-ci = { repository = "google/rust_icu", branch = "master" }

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_upluralrules/README.md
+++ b/rust_icu_upluralrules/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/rust_icu_upluralrules/src/lib.rs
+++ b/rust_icu_upluralrules/src/lib.rs
@@ -1,0 +1,242 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # ICU plural rules support for Rust
+//!
+//! This crate provides locale-sensitive plural rules, based on the list
+//! formatting as implemente by the ICU library.  Specifically, the functionality
+//! exposed through its C API, as available in the [header `upluralrules.h`][header].
+//!
+//!   [header]: https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/upluralrules_8h.html
+//!
+//! > Are you missing some features from this crate?  Consider [reporting an
+//! issue](https://github.com/google/rust_icu/issues) or even [contributing the
+//! functionality](https://github.com/google/rust_icu/pulls).
+
+use {
+    rust_icu_common as common,
+    rust_icu_sys::{self as sys, versioned_function, *},
+    rust_icu_uenum as uenum, rust_icu_ustring as ustring,
+    std::{convert::TryFrom, convert::TryInto, ffi, ptr},
+};
+
+/// The "plural rules" formatter struct.  Create a new instance with [UPluralRules::try_new], or
+/// [UPluralRules::try_new_styled].
+#[derive(Debug)]
+pub struct UPluralRules {
+    // Internal representation is the low-level ICU UPluralRules struct.
+    rep: ptr::NonNull<sys::UPluralRules>,
+}
+
+impl Drop for UPluralRules {
+    /// Implements uplrules_close`.
+    fn drop(&mut self) {
+        unsafe { versioned_function!(uplrules_close)(self.rep.as_ptr()) };
+    }
+}
+
+impl UPluralRules {
+    /// Implements uplrules_open`.
+    pub fn try_new(locale: &str) -> Result<UPluralRules, common::Error> {
+        let locale_cstr = ffi::CString::new(locale)?;
+        let mut status = common::Error::OK_CODE;
+        // Unsafety note: uplrules_open is the way to open a new formatter.
+        let rep = unsafe {
+            assert!(common::Error::is_ok(status));
+            versioned_function!(uplrules_open)(locale_cstr.as_ptr(), &mut status)
+                as *mut sys::UPluralRules
+        };
+        common::Error::ok_or_warning(status)?;
+        assert_ne!(rep, 0 as *mut sys::UPluralRules);
+        Ok(UPluralRules {
+            rep: ptr::NonNull::new(rep).unwrap(),
+        })
+    }
+
+    /// Implements `uplrules_openForType`.
+    pub fn try_new_styled(
+        locale: &str,
+        format_type: sys::UPluralType,
+    ) -> Result<UPluralRules, common::Error> {
+        let locale_cstr = ffi::CString::new(locale)?;
+        let mut status = common::Error::OK_CODE;
+        // Unsafety note: all parameters are safe, so should be valid.
+        let rep = unsafe {
+            assert!(common::Error::is_ok(status));
+            versioned_function!(uplrules_openForType)(
+                locale_cstr.as_ptr(),
+                format_type,
+                &mut status,
+            ) as *mut sys::UPluralRules
+        };
+        common::Error::ok_or_warning(status)?;
+        Ok(UPluralRules {
+            rep: ptr::NonNull::new(rep).unwrap(),
+        })
+    }
+
+    /// Implements `uplrules_select`.
+    pub fn select_ustring(&self, number: f64) -> Result<ustring::UChar, common::Error> {
+        // This could have been a macro "buffered_uchar_method_with_retry", but for some
+        // reason the macro expansion is confused about sys::UChar and ustring::UChar types.
+        const BUFFER_CAPACITY: usize = 20;
+
+        let mut status = common::Error::OK_CODE;
+        let mut buf: Vec<sys::UChar> = vec![0; BUFFER_CAPACITY];
+
+        // Requires that any pointers that are passed in are valid.
+        let full_len: i32 = unsafe {
+            assert!(common::Error::is_ok(status));
+            versioned_function!(uplrules_select)(
+                self.rep.as_ptr(),
+                number,
+                buf.as_mut_ptr(),
+                BUFFER_CAPACITY as i32,
+                &mut status,
+            )
+        };
+
+        // ICU methods are inconsistent in whether they silently truncate the output or treat
+        // the overflow as an error, so we need to check both cases.
+        if status == sys::UErrorCode::U_BUFFER_OVERFLOW_ERROR
+            || (common::Error::is_ok(status)
+                && full_len
+                    > BUFFER_CAPACITY
+                        .try_into()
+                        .map_err(|e| common::Error::wrapper(e))?)
+        {
+            assert!(full_len > 0);
+            let full_len: usize = full_len.try_into().map_err(|e| common::Error::wrapper(e))?;
+            buf.resize(full_len, 0);
+
+            // Same unsafe requirements as above, plus full_len must be exactly the output
+            // buffer size.
+            unsafe {
+                assert!(common::Error::is_ok(status));
+                versioned_function!(uplrules_select)(
+                    self.rep.as_ptr(),
+                    number,
+                    buf.as_mut_ptr(),
+                    full_len as i32,
+                    &mut status,
+                )
+            };
+        }
+        common::Error::ok_or_warning(status)?;
+        // Adjust the size of the buffer here.
+        if full_len >= 0 {
+            let full_len: usize = full_len.try_into().map_err(|e| common::Error::wrapper(e))?;
+            buf.resize(full_len, 0);
+        }
+        Ok(ustring::UChar::from(buf))
+    }
+
+    /// Implements `uplrules_select`.
+    pub fn select(&self, number: f64) -> Result<String, common::Error> {
+        let result = self.select_ustring(number);
+        match result {
+            Err(e) => Err(e),
+            Ok(u) => String::try_from(&u).map_err(|e| e.into()),
+        }
+    }
+
+    /// Implements `uplrules_getKeywords`
+    pub fn get_keywords(&self) -> Result<uenum::Enumeration, common::Error> {
+        let mut status = UErrorCode::U_ZERO_ERROR;
+        let raw_enum = unsafe {
+            assert_eq!(status, UErrorCode::U_ZERO_ERROR);
+            versioned_function!(uplrules_getKeywords)(self.rep.as_ptr(), &mut status)
+        };
+        common::Error::ok_or_warning(status)?;
+        Ok(unsafe {
+            assert_ne!(raw_enum, 0 as *mut sys::UEnumeration);
+            uenum::Enumeration::from_raw_parts(None, raw_enum)
+        })
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use super::*;
+
+    #[test]
+    fn plurals_ar_eg() -> Result<(), common::Error> {
+        let pl = crate::UPluralRules::try_new("ar_EG").expect("locale ar_EG exists");
+        assert_eq!("zero", pl.select(0 as f64)?);
+        assert_eq!("one", pl.select(1 as f64)?);
+        assert_eq!("two", pl.select(2 as f64)?);
+        assert_eq!("few", pl.select(6 as f64)?);
+        assert_eq!("many", pl.select(18 as f64)?);
+        Ok(())
+    }
+
+    #[test]
+    fn plurals_ar_eg_styled() -> Result<(), common::Error> {
+        let pl = crate::UPluralRules::try_new_styled("ar_EG", UPluralType::UPLURAL_TYPE_ORDINAL)
+            .expect("locale ar_EG exists");
+        assert_eq!("other", pl.select(0 as f64)?);
+        assert_eq!("other", pl.select(1 as f64)?);
+        assert_eq!("other", pl.select(2 as f64)?);
+        assert_eq!("other", pl.select(6 as f64)?);
+        assert_eq!("other", pl.select(18 as f64)?);
+        Ok(())
+    }
+
+    #[test]
+    fn plurals_sr_rs() -> Result<(), common::Error> {
+        let pl = crate::UPluralRules::try_new("sr_RS").expect("locale sr_RS exists");
+        assert_eq!("other", pl.select(0 as f64)?);
+        assert_eq!("one", pl.select(1 as f64)?);
+        assert_eq!("few", pl.select(2 as f64)?);
+        assert_eq!("few", pl.select(4 as f64)?);
+        assert_eq!("other", pl.select(5 as f64)?);
+        assert_eq!("other", pl.select(6 as f64)?);
+        assert_eq!("other", pl.select(18 as f64)?);
+        assert_eq!("other", pl.select(11 as f64)?);
+
+        assert_eq!("one", pl.select(21 as f64)?);
+        Ok(())
+    }
+
+    #[test]
+    fn plurals_sr_rs_styled() -> Result<(), common::Error> {
+        let pl = crate::UPluralRules::try_new_styled("sr_RS", UPluralType::UPLURAL_TYPE_ORDINAL)
+            .expect("locale sr_RS exists");
+        assert_eq!("other", pl.select(0 as f64)?);
+        assert_eq!("other", pl.select(1 as f64)?);
+        assert_eq!("other", pl.select(2 as f64)?);
+        assert_eq!("other", pl.select(6 as f64)?);
+        assert_eq!("other", pl.select(18 as f64)?);
+        Ok(())
+    }
+
+    #[test]
+    fn all_keywords() -> Result<(), common::Error> {
+        let pl = crate::UPluralRules::try_new("sr_RS").expect("locale sr_RS exists");
+        let e = pl.get_keywords()?;
+        let all: Vec<String> = e.into_iter().map(|r| r.unwrap()).collect();
+        assert_eq!(vec!["few", "one", "other"], all);
+        Ok(())
+    }
+
+    #[test]
+    fn all_keywords_styled() -> Result<(), common::Error> {
+        let pl = crate::UPluralRules::try_new_styled("sr_RS", UPluralType::UPLURAL_TYPE_ORDINAL)
+            .expect("locale sr_RS exists");
+        let e = pl.get_keywords()?;
+        let all: Vec<String> = e.into_iter().map(|r| r.unwrap()).collect();
+        assert_eq!(vec!["other"], all);
+        Ok(())
+    }
+}

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.3.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "0.1.5"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]


### PR DESCRIPTION
Adds the support for locale-sensitive plural rules

Plural rules determines what gets printed when one needs to format "1 file"
or "10 files" for human consumption.  Each language may have very own rules
about what number is considered singular, what is considered plural.

Languages have different rules about the numbers subject to the rule, and
even about the number of plurals that are used.

Closes #127
