### PR TITLE
Implements ECMA 402 pluralrules using ICU

### DIFF
--- a/ecma402_traits/src/lib.rs
+++ b/ecma402_traits/src/lib.rs
@@ -29,10 +29,9 @@ pub trait Locale: fmt::Display {}
 ///
 pub mod listformat;
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+/// A Rust implementation of ECMA 402 PluralRules API.
+///
+/// The [pluralrules] mod contains all the needed implementation bits for `Intl.PluralRules`.
+///
+pub mod pluralrules;
+

--- a/ecma402_traits/src/listformat.rs
+++ b/ecma402_traits/src/listformat.rs
@@ -113,7 +113,7 @@ pub trait Format {
     /// > Note:
     /// > - Should there be a convenience method that prints to string specifically?
     /// > - Do we need `format_into_parts`?
-    fn format<I, L, W>(self, list: L, writer: &mut W) -> fmt::Result
+    fn format<I, L, W>(&self, list: L, writer: &mut W) -> fmt::Result
     where
         I: fmt::Display,
         L: IntoIterator<Item = I>,

--- a/ecma402_traits/src/pluralrules.rs
+++ b/ecma402_traits/src/pluralrules.rs
@@ -76,7 +76,7 @@ pub trait PluralRules {
     /// The type of error reported, if any.
     type Error: std::error::Error;
 
-    /// Creates a new [Rules].
+    /// Creates a new [PluralRules].
     ///
     /// Creation may fail, for example, if the locale-specific data is not loaded, or if
     /// the supplied options are inconsistent.
@@ -91,7 +91,7 @@ pub trait PluralRules {
     ///
     ///    [plr]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules
     ///    [ecma]: https://www.ecma-international.org/publications/standards/Ecma-402.htm
-    fn select<W>(self, number: f64, writer: &mut W) -> fmt::Result
+    fn select<W>(&self, number: f64, writer: &mut W) -> fmt::Result
     where
         W: fmt::Write;
 }

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -22,6 +22,7 @@ rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features =
 rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.0", default-features = false }
 rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
 rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.3.0", default-features = false }
+rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "0.3.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"
@@ -35,6 +36,7 @@ use-bindgen = [
   "rust_icu_sys/use-bindgen",
   "rust_icu_ulistformatter/use-bindgen",
   "rust_icu_uloc/use-bindgen",
+  "rust_icu_upluralrules/use-bindgen",
   "rust_icu_ustring/use-bindgen",
 ]
 renaming = [
@@ -42,6 +44,7 @@ renaming = [
   "rust_icu_sys/renaming",
   "rust_icu_ulistformatter/renaming",
   "rust_icu_uloc/renaming",
+  "rust_icu_upluralrules/renaming",
   "rust_icu_ustring/renaming",
 ]
 icu_config = [
@@ -49,6 +52,7 @@ icu_config = [
   "rust_icu_sys/icu_config",
   "rust_icu_ulistformatter/icu_config",
   "rust_icu_uloc/icu_config",
+  "rust_icu_upluralrules/icu_config",
   "rust_icu_ustring/icu_config",
 ]
 icu_version_in_env = [
@@ -56,6 +60,7 @@ icu_version_in_env = [
   "rust_icu_sys/icu_version_in_env",
   "rust_icu_ulistformatter/icu_version_in_env",
   "rust_icu_uloc/icu_version_in_env",
+  "rust_icu_upluralrules/icu_version_in_env",
   "rust_icu_ustring/icu_version_in_env",
 ]
 icu_version_64_plus = [
@@ -63,6 +68,7 @@ icu_version_64_plus = [
   "rust_icu_sys/icu_version_64_plus",
   "rust_icu_ustring/icu_version_64_plus",
   "rust_icu_uloc/icu_version_64_plus",
+  "rust_icu_upluralrules/icu_version_64_plus",
   "rust_icu_ulistformatter/icu_version_64_plus",
 ]
 icu_version_67_plus = [
@@ -70,6 +76,7 @@ icu_version_67_plus = [
   "rust_icu_sys/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
   "rust_icu_uloc/icu_version_67_plus",
+  "rust_icu_upluralrules/icu_version_67_plus",
   "rust_icu_ulistformatter/icu_version_67_plus",
 ]
 

--- a/rust_icu_ecma402/src/lib.rs
+++ b/rust_icu_ecma402/src/lib.rs
@@ -15,3 +15,6 @@
 /// Implements ECMA-402 `Intl.ListFormat`.
 pub mod listformat;
 
+/// Implements ECMA-402 `Intl.PluralRules`.
+pub mod pluralrules;
+

--- a/rust_icu_ecma402/src/listformat.rs
+++ b/rust_icu_ecma402/src/listformat.rs
@@ -81,7 +81,7 @@ impl listformat::Format for Format {
     }
 
     /// Formats the given string.
-    fn format<I, L, W>(self, list: L, f: &mut W) -> fmt::Result
+    fn format<I, L, W>(&self, list: L, f: &mut W) -> fmt::Result
     where
         I: fmt::Display,
         L: IntoIterator<Item = I>,

--- a/rust_icu_ecma402/src/pluralrules.rs
+++ b/rust_icu_ecma402/src/pluralrules.rs
@@ -1,0 +1,142 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implements the traits found in [ecma402_traits::pluralrules].
+
+use ecma402_traits;
+use rust_icu_common as common;
+use rust_icu_upluralrules as uplr;
+use std::fmt;
+
+/// Implements [ecma402_traits::pluralrules::PluralRules] using ICU as the underlying
+/// implementing library.
+pub struct PluralRules {
+    // The internal representation of rules.
+    rep: uplr::UPluralRules,
+}
+
+pub(crate) mod internal {
+    use ecma402_traits::pluralrules::options;
+    use rust_icu_sys as usys;
+
+    // Converts the trait style option type to an equivalente ICU type.
+    pub fn to_icu_type(style: &options::Type) -> usys::UPluralType {
+        match style {
+            options::Type::Ordinal => usys::UPluralType::UPLURAL_TYPE_ORDINAL,
+            options::Type::Cardinal => usys::UPluralType::UPLURAL_TYPE_CARDINAL,
+        }
+    }
+}
+
+impl ecma402_traits::pluralrules::PluralRules for PluralRules {
+    type Error = common::Error;
+
+    /// Creates a new [PluralRules].
+    ///
+    /// Creation may fail, for example, if the locale-specific data is not loaded, or if
+    /// the supplied options are inconsistent.
+    ///
+    /// > Note: not yet implemented: the formatting constraints (min integer digits and such).
+    fn try_new<L>(l: L, opts: ecma402_traits::pluralrules::Options) -> Result<Self, Self::Error>
+    where
+        L: ecma402_traits::Locale,
+        Self: Sized,
+    {
+        let locale = format!("{}", l);
+        let style_type = internal::to_icu_type(&opts.in_type);
+        let rep = uplr::UPluralRules::try_new_styled(&locale, style_type)?;
+        Ok(PluralRules { rep })
+    }
+
+    /// Formats the plural class of `number` into the supplied `writer`.
+    ///
+    /// The function implements [`Intl.PluralRules`][plr] from [ECMA 402][ecma].
+    ///
+    ///    [plr]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules
+    ///    [ecma]: https://www.ecma-international.org/publications/standards/Ecma-402.htm
+    fn select<W>(&self, number: f64, writer: &mut W) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        let result = self.rep.select(number).map_err(|e| e.into())?;
+        write!(writer, "{}", result)
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use super::*;
+    use ecma402_traits::pluralrules;
+    use ecma402_traits::pluralrules::PluralRules;
+    use rust_icu_uloc as uloc;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn plurals_per_locale() -> Result<(), common::Error> {
+        #[derive(Debug, Clone)]
+        struct TestCase {
+            locale: &'static str,
+            opts: pluralrules::Options,
+            numbers: Vec<f64>,
+            expected: Vec<&'static str>,
+        };
+        let tests = vec![
+            TestCase {
+                locale: "ar_EG",
+                opts: Default::default(),
+                numbers: vec![0 as f64, 1 as f64, 2 as f64, 6 as f64, 18 as f64],
+                expected: vec!["zero", "one", "two", "few", "many"],
+            },
+            TestCase {
+                locale: "ar_EG",
+                opts: pluralrules::Options {
+                    in_type: pluralrules::options::Type::Ordinal,
+                    .. Default::default()
+                },
+                numbers: vec![0 as f64, 1 as f64, 2 as f64, 6 as f64, 18 as f64],
+                expected: vec!["other", "other", "other", "other", "other"],
+            },
+            TestCase {
+                locale: "sr_RS",
+                opts: Default::default(),
+                numbers: vec![0 as f64, 1 as f64, 2 as f64, 4 as f64, 6 as f64, 18 as f64],
+                expected: vec!["other", "one", "few", "few", "other", "other"],
+            },
+            TestCase {
+                locale: "sr_RS",
+                opts: pluralrules::Options {
+                    in_type: pluralrules::options::Type::Ordinal,
+                    .. Default::default()
+                },
+                numbers: vec![0 as f64, 1 as f64, 2 as f64, 4 as f64, 6 as f64, 18 as f64],
+                expected: vec!["other", "other", "other", "other", "other", "other"],
+            },
+        ];
+        for test in tests {
+            let locale = uloc::ULoc::try_from(test.locale).expect("locale exists");
+            let plr = super::PluralRules::try_new(locale, test.clone().opts)?;
+            let actual = test
+                .numbers
+                .iter()
+                .map(|n| {
+                    let mut result = String::new();
+                    plr.select(*n, &mut result).unwrap();
+                    result
+                })
+                .collect::<Vec<String>>();
+            assert_eq!(test.expected, actual, "for test case: {:?}", &test);
+        }
+        Ok(())
+    }
+}

--- a/rust_icu_ecma402/src/pluralrules.rs
+++ b/rust_icu_ecma402/src/pluralrules.rs
@@ -30,7 +30,7 @@ pub(crate) mod internal {
     use ecma402_traits::pluralrules::options;
     use rust_icu_sys as usys;
 
-    // Converts the trait style option type to an equivalente ICU type.
+    // Converts the trait style option type to an equivalent ICU type.
     pub fn to_icu_type(style: &options::Type) -> usys::UPluralType {
         match style {
             options::Type::Ordinal => usys::UPluralType::UPLURAL_TYPE_ORDINAL,


### PR DESCRIPTION
Adds the `select` implementation that does not use the formatting hints
from the number formatter.

That's being left for followup work.