### PR TITLE
Unum part 3

### DIFF
--- a/rust_icu_uformattable/src/lib.rs
+++ b/rust_icu_uformattable/src/lib.rs
@@ -96,6 +96,21 @@ impl<'a> crate::UFormattable<'a> {
         })
     }
 
+    /// Reveals the underlying representation as a mutable pointer.
+    ///
+    /// **DO NOT USE UNLESS YOU HAVE NO OTHER CHOICE**
+    ///
+    /// The intended use of this method is for other crates that need to obtain
+    /// low-level representations of this type.
+    #[doc(hidden)]
+    pub fn as_mut_ptr(&mut self) -> *mut sys::UFormattable {
+        self.rep.as_ptr()
+    }
+
+    pub fn as_ptr(&self) -> *const sys::UFormattable {
+        self.rep.as_ptr()
+    }
+
     /// Returns `true` if this formattable is numeric.
     ///
     /// Implements `ufmt_isNumeric`

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4.6"
 paste = "0.1.5"
 rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
 rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "0.3.1", default-features = false }
 rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.1", default-features = false }
 rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
 anyhow = "1.0.25"
@@ -34,36 +35,42 @@ default = ["use-bindgen", "renaming", "icu_config"]
 use-bindgen = [
   "rust_icu_common/use-bindgen",
   "rust_icu_sys/use-bindgen",
+  "rust_icu_uformattable/use-bindgen",
   "rust_icu_uloc/use-bindgen",
   "rust_icu_ustring/use-bindgen",
 ]
 renaming = [
   "rust_icu_common/renaming",
   "rust_icu_sys/renaming",
+  "rust_icu_uformattable/renaming",
   "rust_icu_uloc/renaming",
   "rust_icu_ustring/renaming",
 ]
 icu_config = [
   "rust_icu_common/icu_config",
   "rust_icu_sys/icu_config",
+  "rust_icu_uformattable/icu_config",
   "rust_icu_uloc/icu_config",
   "rust_icu_ustring/icu_config",
 ]
 icu_version_in_env = [
   "rust_icu_common/icu_version_in_env",
   "rust_icu_sys/icu_version_in_env",
+  "rust_icu_uformattable/icu_version_in_env",
   "rust_icu_uloc/icu_version_in_env",
   "rust_icu_ustring/icu_version_in_env",
 ]
 icu_version_64_plus = [
   "rust_icu_common/icu_version_64_plus",
   "rust_icu_sys/icu_version_64_plus",
+  "rust_icu_uformattable/icu_version_64_plus",
   "rust_icu_uloc/icu_version_64_plus",
   "rust_icu_ustring/icu_version_64_plus",
 ]
 icu_version_67_plus = [
   "rust_icu_common/icu_version_67_plus",
   "rust_icu_sys/icu_version_67_plus",
+  "rust_icu_uformattable/icu_version_67_plus",
   "rust_icu_uloc/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]


### PR DESCRIPTION
Part 3 in the unum number formatting support work.

Please see individual commits for details of the change.

# Adds support for UFormattable.

Using uformattable::UFormattable provides
generalized value parsing for the particular
locale.

While this isn't the full spectrum of the
underlying functions that ICU4C provides
for value parsing, it's general enough
to be usable for all the use cases where
parsing is needed, *if* needed.  However,
those uses are rare.

Issue #141.