### PR TITLE
Turns off the improper C type warning for variadic arg.

### DIFF
--- a/rust_icu_umsg/src/lib.rs
+++ b/rust_icu_umsg/src/lib.rs
@@ -335,6 +335,10 @@ macro_rules! checkarg {
 }
 
 // TODO: is there a way to *not* expose this function?
+// Has to be declared as extern "C" to allow for variadic args; but since the
+// return type is not C-clean, then we need to suppress the improper type
+// definition.
+#[allow(improper_ctypes_definitions)]
 #[no_mangle]
 #[doc(hidden)]
 pub unsafe extern "C" fn format_varargs(


### PR DESCRIPTION
Message formatting must have extern "C" as it uses C variadic args;
but its return type is not FFI clean, and the compiler emits a warning.

As we don't intend to use this function in the FFI context, we don't care
about the warning, and therefore turn it off.