### PR TITLE
Start using ICU 67 as default for docker tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ CARGO_TARGET_DIR := ${TMP}/rust_icu-${LOGNAME}-target
 # Pass different values for DOCKER_TEST_ENV and DOCKER_TEST_CARGO_TEST_ARGS to
 # test different configurations.  This is useful in Travis CI matrix tests, for
 # example.
-RUST_ICU_MAJOR_VERSION_NUMBER ?= 64
+RUST_ICU_MAJOR_VERSION_NUMBER ?= 67
 DOCKER_TEST_ENV ?= rust_icu_testenv-${RUST_ICU_MAJOR_VERSION_NUMBER}
 DOCKER_TEST_CARGO_TEST_ARGS ?= 
 docker-test:


### PR DESCRIPTION
As we've moved Fuchsia to ICU 67, we may as well bump the version
up here.

Ideally, we'd keep this close to the newest supported ICU library
version.  We kept this on 64 to match Fuchsia; now this is no
longer needed.