### PR TITLE
Use rust:1.45 as installation base

### DIFF
--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -1,5 +1,5 @@
 # rust_icu_buildenv.
-FROM rust:1.40 AS buildenv
+FROM rust:1.45 AS buildenv
 
 RUN mkdir -p /src
 


### PR DESCRIPTION
This should allow us to accept https://github.com/google/rust_icu/pull/158

(Will still need to update the `USED_BUILDENV_VERSION` in the `Makefile`)