### PR TITLE
Start using buildenv-1.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 #   make USED_BUILDENV_VERSION=whatever-you-want docker-test
 #
 # NOTE: This version number is completely independent of the crate version.
-USED_BUILDENV_VERSION ?= 1.1.0
+USED_BUILDENV_VERSION ?= 1.3.0
 
 CARGO_FEATURE_VERSION :=
 


### PR DESCRIPTION
This starts using a newer nightly Rust toolchain (1.47)
which, in turn, can compile paste-1.0.0 from pull
request: #158
 