### PR TITLE
Makes ecma402_traits an optional dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         icu_version: [63]
         feature_set: 
-          - "renaming,icu_version_in_env"
+          - "renaming,icu_version_in_env,use_ecma402"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}
@@ -32,8 +32,8 @@ jobs:
       matrix:
         icu_version: [64, 65]
         feature_set: 
-          - "renaming,icu_version_in_env,icu_version_64_plus"
-          - "renaming,icu_version_64_plus,icu_config,use-bindgen"
+          - "renaming,icu_version_in_env,icu_version_64_plus,use_ecma402"
+          - "renaming,icu_version_64_plus,icu_config,use-bindgen,use_ecma402"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}
@@ -44,8 +44,8 @@ jobs:
       matrix:
         icu_version: [67]
         feature_set: 
-          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus"
-          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_config,use-bindgen"
+          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus,use_ecma402"
+          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_config,use-bindgen,use_ecma402"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ confusing compilation end result.
 | `renaming` | Yes | If set, ICU bindings are generated with version numbers appended.  This is called "renaming" in ICU, and is normally needed only when linking against specific ICU version is required, for example to work around having to link different ICU versions.  See [the ICU documentation](http://userguide.icu-project.org/design) for a discussion of renaming. **This feature MUST be used when `bindgen` is NOT used.** |
 | `icu_config` | Yes | If set, the binary icu-config will be used to configure the library.  Turn this feature off if you do not want `build.rs` to try to autodetect the build environment.  You will want to skip this feature if your build environment configures ICU in a different way. **This feature is only meaningful when `bindgen` feature is used; otherwise it has no effect.** |
 | `icu_version_in_env` | No | If set, ICU bindings are made for the ICU version specified in the environment variable `RUST_ICU_MAJOR_VERSION_NUMBER`, which is made available to cargo at build time. See section below for details on how to use this feature. **This feature is only meaningful when `bindgen` feature is NOT used; otherwise it has no effect.** |
+| `use_ecma402` | No | If set, the library will take a dependency on `ecma402_traits` crate, which is used to implement ECMA402 compatibility features.  This is only useful when using the crate `rust_icu_ecma402`, so it is not enabled by default. |
 
 # Prerequisites
 

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -35,6 +35,9 @@ icu_version_64_plus = [
 icu_version_67_plus = [
   "rust_icu_sys/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_sys/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -31,8 +31,11 @@ anyhow = "1.0.25"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["use-bindgen", "renaming", "icu_config"]
+default = ["use-bindgen", "renaming", "icu_config", "use_ecma402"]
 
+use_ecma402 = [
+  "rust_icu_uloc/use_ecma402",
+]
 use-bindgen = [
   "rust_icu_common/use-bindgen",
   "rust_icu_sys/use-bindgen",

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -70,4 +70,10 @@ icu_version_67_plus = [
   "rust_icu_umsg/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_uloc/use_ecma402",
+  "rust_icu_umsg/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -40,6 +40,7 @@ icu_config = []
 icu_version_in_env = []
 icu_version_64_plus = []
 icu_version_67_plus = []
+use_ecma402 = []
 
 
 [badges]

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -66,6 +66,12 @@ use-bindgen = [
   "rust_icu_uloc/use-bindgen",
   "rust_icu_ustring/use-bindgen",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_uloc/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "google/rust_icu" }

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -67,6 +67,12 @@ icu_version_67_plus = [
   "rust_icu_uenum/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_uenum/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -67,6 +67,12 @@ icu_version_67_plus = [
   "rust_icu_uenum/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_uenum/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -77,6 +77,14 @@ icu_version_67_plus = [
   "rust_icu_uloc/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_ucal/use_ecma402",
+  "rust_icu_uenum/use_ecma402",
+  "rust_icu_uloc/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -37,6 +37,10 @@ icu_version_67_plus = [
   "rust_icu_common/icu_version_67_plus",
   "rust_icu_sys/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -36,6 +36,10 @@ icu_version_67_plus = [
   "rust_icu_common/icu_version_67_plus",
   "rust_icu_sys/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -60,6 +60,11 @@ icu_version_67_plus = [
   "rust_icu_sys/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -60,6 +60,11 @@ icu_version_67_plus = [
   "rust_icu_sys/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -23,7 +23,7 @@ rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-feat
 rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
 rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.2", default-features = false }
 rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
-ecma402_traits = { path = "../ecma402_traits", version = "0.2.0" }
+ecma402_traits = { path = "../ecma402_traits", version = "0.2.0", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.25"
@@ -67,6 +67,13 @@ icu_version_67_plus = [
   "rust_icu_sys/icu_version_67_plus",
   "rust_icu_uenum/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
+]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_uenum/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+  "ecma402_traits",
 ]
 
 [build-dependencies]

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -26,9 +26,10 @@ use {
         os::raw,
         fmt,
     },
-
-    ecma402_traits,
 };
+
+#[cfg(feature="use_ecma402")]
+use ecma402_traits;
 
 /// Maximum length of locale supported by uloc.h.
 /// See `ULOC_FULLNAME_CAPACITY`.
@@ -55,6 +56,7 @@ impl fmt::Display for ULoc {
     }
 }
 /// Marker implementation for ULoc.
+#[cfg(feature="use_ecma402")]
 impl ecma402_traits::Locale for ULoc {}
 
 impl TryFrom<&str> for ULoc {

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -68,6 +68,12 @@ icu_version_67_plus = [
   "rust_icu_uloc/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_uloc/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -74,6 +74,13 @@ icu_version_67_plus = [
   "rust_icu_uloc/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_uformattable/use_ecma402",
+  "rust_icu_uloc/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -81,6 +81,14 @@ icu_version_67_plus = [
   "rust_icu_unum/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_uformattable/use_ecma402",
+  "rust_icu_uloc/use_ecma402",
+  "rust_icu_unum/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -67,6 +67,12 @@ icu_version_67_plus = [
   "rust_icu_uenum/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_uenum/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -37,4 +37,8 @@ icu_version_67_plus = [
   "rust_icu_common/icu_version_67_plus",
   "rust_icu_sys/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+]
 

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -36,6 +36,10 @@ icu_version_67_plus = [
   "rust_icu_common/icu_version_67_plus",
   "rust_icu_sys/icu_version_67_plus",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -67,6 +67,12 @@ use-bindgen = [
   "rust_icu_uenum/use-bindgen",
   "rust_icu_ustring/use-bindgen",
 ]
+use_ecma402 = [
+  "rust_icu_common/use_ecma402",
+  "rust_icu_sys/use_ecma402",
+  "rust_icu_uenum/use_ecma402",
+  "rust_icu_ustring/use_ecma402",
+]
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "google/rust_icu" }


### PR DESCRIPTION
This removes the need for every use of `rust_icu_uloc` to
depend on `ecma420_traits` if the marker implementation of
`ecma402_traits::Locale` is not in fact being used.

This happens for example when you are using `rust_icu`
directly and not through any ECMA402 compatible API. This change
should, for example, remove the need for Fuchsia code base to
vendor ecma402_traits.

Closes #171.