### PR TITLE
Remove dep on ecma402

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         icu_version: [63]
         feature_set: 
-          - "renaming,icu_version_in_env,use_ecma402"
+          - "renaming,icu_version_in_env"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}
@@ -32,8 +32,8 @@ jobs:
       matrix:
         icu_version: [64, 65]
         feature_set: 
-          - "renaming,icu_version_in_env,icu_version_64_plus,use_ecma402"
-          - "renaming,icu_version_64_plus,icu_config,use-bindgen,use_ecma402"
+          - "renaming,icu_version_in_env,icu_version_64_plus"
+          - "renaming,icu_version_64_plus,icu_config,use-bindgen"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}
@@ -44,8 +44,8 @@ jobs:
       matrix:
         icu_version: [67]
         feature_set: 
-          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus,use_ecma402"
-          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_config,use-bindgen,use_ecma402"
+          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus"
+          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_config,use-bindgen"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}

--- a/Makefile
+++ b/Makefile
@@ -138,12 +138,14 @@ publish:
 	$(call publish,rust_icu_ubrk)
 	$(call publish,rust_icu_utrans)
 	$(call publish,rust_icu)
+	$(call publish,rust_icu_ecma402)
+	$(call publish,rust_icu_unumberformatter)
 
 # A helper to up-rev the cargo crate versions.
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
-UPREV_OLD_VERSION ?= 0.3.2
-UPREV_NEW_VERSION ?= 0.3.3
+UPREV_OLD_VERSION ?= 0.4.0
+UPREV_NEW_VERSION ?= 0.4.1
 define uprev
 	( \
 		cd $(1) && \
@@ -170,8 +172,10 @@ uprev:
 	$(call uprev,rust_icu_utext)
 	$(call uprev,rust_icu_uformattable)
 	$(call uprev,rust_icu_unum)
+	$(call uprev,rust_icu_unumberformatter)
 	$(call uprev,rust_icu_ubrk)
 	$(call uprev,rust_icu_utrans)
+	$(call uprev,rust_icu_ecma402)
 
 cov:
 	./build/showprogress.sh

--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ Feature              | Default? | Description
 `renaming`           | Yes      | If set, ICU bindings are generated with version numbers appended. This is called "renaming" in ICU, and is normally needed only when linking against specific ICU version is required, for example to work around having to link different ICU versions. See [the ICU documentation](http://userguide.icu-project.org/design) for a discussion of renaming. **This feature MUST be used when `bindgen` is NOT used.**
 `icu_config`         | Yes      | If set, the binary icu-config will be used to configure the library. Turn this feature off if you do not want `build.rs` to try to autodetect the build environment. You will want to skip this feature if your build environment configures ICU in a different way. **This feature is only meaningful when `bindgen` feature is used; otherwise it has no effect.**
 `icu_version_in_env` | No       | If set, ICU bindings are made for the ICU version specified in the environment variable `RUST_ICU_MAJOR_VERSION_NUMBER`, which is made available to cargo at build time. See section below for details on how to use this feature. **This feature is only meaningful when `bindgen` feature is NOT used; otherwise it has no effect.**
-`use_ecma402`        | No       | If set, the library will take a dependency on `ecma402_traits` crate, which is used to implement ECMA402 compatibility features. This is only useful when using the crate `rust_icu_ecma402`, so it is not enabled by default.
 
 # Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -100,28 +100,15 @@ The limitations we know of today are as follows:
 
 # Compatibility
 
-The table below shows the support matrix that has been verified so far. Any
-versions not mentioned explicitly have not been tested. No guarantees are made
-for those versions.
+Up to 3 minor releases of `rust_icu` are tested for each major release, and
+automated tests are executed for all ICU library versions of interest, in all
+feature combinations of interest.
 
-## Feature sets
-
-For an explanation of features, see the [Features section](#features) below.
-
-*   1: default
-*   2: "renaming"
-*   3: "icu_version_in_env"
-
-## Compatibility matrix
-
-Each cell in the table shows which feature set combination has been tested for
-this particular ICU library and `rust_icu` version combination.
-
-`rust_icu` version | ICU 63.x | ICU 64.2 | ICU 65.1 | ICU 66.0.1 | ICU 67.1
+`rust_icu` version   | ICU 63.x | ICU 64.2 | ICU 65.1 | ICU 66.0.1 | ICU 67.1
 ------------------ | -------- | -------- | -------- | ---------- | --------
-0.1                | 1        | 1        | 1;2;2+3  | 1          | 1
-0.2                | 1;2;2+3  | 1;2;2+3  | 1;2;2+3  | 1;2;2+3    | 1;2;2+3
-0.3                | 1;2;2+3  | 1;2;2+3  | 1;2;2+3  | 1;2;2+3    | 1;2;2+3
+0.2                |    ✅    |    ✅    |    ✅    |    ✅      |    ✅
+0.3                |    ✅    |    ✅    |    ✅    |    ✅      |    ✅
+0.4                |    ✅    |    ✅    |    ✅    |    ✅      |    ✅
 
 > Prior to a 1.0.0 release, API versions that only differ in the patch version
 > number (0.x.**y**) only should be compatible.

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,20 +18,20 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "0.3.2", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.2", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "0.3.2", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "0.3.2", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "0.3.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.2", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.3.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.2", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "0.3.2", default-features = false }
-rust_icu_utrans = { path = "../rust_icu_utrans", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "0.4.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.4.0", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "0.4.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "0.4.0", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "0.4.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.4.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.4.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.4.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "0.4.0", default-features = false }
+rust_icu_utrans = { path = "../rust_icu_utrans", version = "0.4.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -35,9 +35,6 @@ icu_version_64_plus = [
 icu_version_67_plus = [
   "rust_icu_sys/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_sys/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "rust_icu_ecma402"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.0"
+version = "0.4.0"
 
 description = """
 ECMA 402 standard implementation in Rust.
@@ -17,14 +17,14 @@ anyhow = "1.0.25"
 ecma402_traits = { path = "../ecma402_traits", version = "0.2.0" }
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.0", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.3.0", default-features = false }
-rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "0.3.0", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "0.3.0", default-features = false }
-rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "0.3.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.4.0", default-features = false }
+rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "0.4.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "0.4.0", default-features = false }
+rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -31,11 +31,8 @@ anyhow = "1.0.25"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]
-default = ["use-bindgen", "renaming", "icu_config", "use_ecma402"]
+default = ["use-bindgen", "renaming", "icu_config"]
 
-use_ecma402 = [
-  "rust_icu_uloc/use_ecma402",
-]
 use-bindgen = [
   "rust_icu_common/use-bindgen",
   "rust_icu_sys/use-bindgen",

--- a/rust_icu_ecma402/src/lib.rs
+++ b/rust_icu_ecma402/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rust_icu_uloc::ULoc;
+
 /// Implements ECMA-402 [`Intl.ListFormat`][link].
 ///
 /// [link]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat
@@ -27,4 +29,18 @@ pub mod pluralrules;
 /// [link]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
 pub mod numberformat;
 
+pub enum Locale {
+    FromULoc(ULoc),
+}
 
+impl ecma402_traits::Locale for crate::Locale {}
+
+impl std::fmt::Display for Locale {
+    /// Implementation that delegates printing the locale to the underlying
+    /// `rust_icu` implementation.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Locale::FromULoc(ref l) =>  write!(f, "{}", l),
+        }
+    }
+}

--- a/rust_icu_ecma402/src/listformat.rs
+++ b/rust_icu_ecma402/src/listformat.rs
@@ -29,8 +29,8 @@ pub struct Format {
 // Full support for styled formatting is available since v67.
 #[cfg(feature = "icu_version_67_plus")]
 pub(crate) mod internal {
-    use rust_icu_sys as usys;
     use ecma402_traits::listformat::options;
+    use rust_icu_sys as usys;
 
     // Converts the param types from ECMA-402 into ICU.
     pub fn to_icu_width(style: &options::Style) -> usys::UListFormatterWidth {
@@ -216,9 +216,10 @@ mod testing {
         ];
 
         for test in tests {
-            let locale = uloc::ULoc::try_from(test.locale).expect("locale exists");
+            let locale =
+                crate::Locale::FromULoc(uloc::ULoc::try_from(test.locale).expect("locale exists"));
             let formatter =
-                super::Format::try_new(locale.clone(), test.opts.clone()).expect("has list format");
+                super::Format::try_new(locale, test.opts.clone()).expect("has list format");
 
             let mut result = String::new();
             formatter

--- a/rust_icu_ecma402/src/numberformat.rs
+++ b/rust_icu_ecma402/src/numberformat.rs
@@ -199,10 +199,7 @@ pub(crate) mod internal {
         let ats: String = std::iter::repeat("@").take(min_sig).collect();
         let hashes_sig: String = std::iter::repeat("#").take(max_sig - min_sig).collect();
 
-        return format!(
-            ".{}{}/{}{}",
-            zeroes, hashes, ats, hashes_sig, 
-        );
+        return format!(".{}{}/{}{}", zeroes, hashes, ats, hashes_sig,);
     }
 
     #[cfg(test)]
@@ -316,18 +313,19 @@ mod testing {
             },
             // TODO: This ends up being a syntax error, why?
             //TestCase {
-                //locale: "en-IN",
-                //opts: numberformat::Options {
-                    //maximum_significant_digits: Some(3),
-                    //..Default::default()
-                //},
-                //numbers: vec![123456.789],
-                //expected: vec!["1,23,000"],
+            //locale: "en-IN",
+            //opts: numberformat::Options {
+            //maximum_significant_digits: Some(3),
+            //..Default::default()
+            //},
+            //numbers: vec![123456.789],
+            //expected: vec!["1,23,000"],
             //},
         ];
         for test in tests {
-            let locale =
-                uloc::ULoc::try_from(test.locale).expect(&format!("locale exists: {:?}", &test));
+            let locale = crate::Locale::FromULoc(
+                uloc::ULoc::try_from(test.locale).expect(&format!("locale exists: {:?}", &test)),
+            );
             let format = crate::numberformat::NumberFormat::try_new(locale, test.clone().opts)
                 .expect(&format!("try_from should succeed: {:?}", &test));
             let actual = test

--- a/rust_icu_ecma402/src/pluralrules.rs
+++ b/rust_icu_ecma402/src/pluralrules.rs
@@ -102,7 +102,7 @@ mod testing {
                 locale: "ar_EG",
                 opts: pluralrules::Options {
                     in_type: pluralrules::options::Type::Ordinal,
-                    .. Default::default()
+                    ..Default::default()
                 },
                 numbers: vec![0 as f64, 1 as f64, 2 as f64, 6 as f64, 18 as f64],
                 expected: vec!["other", "other", "other", "other", "other"],
@@ -117,14 +117,15 @@ mod testing {
                 locale: "sr_RS",
                 opts: pluralrules::Options {
                     in_type: pluralrules::options::Type::Ordinal,
-                    .. Default::default()
+                    ..Default::default()
                 },
                 numbers: vec![0 as f64, 1 as f64, 2 as f64, 4 as f64, 6 as f64, 18 as f64],
                 expected: vec!["other", "other", "other", "other", "other", "other"],
             },
         ];
         for test in tests {
-            let locale = uloc::ULoc::try_from(test.locale).expect("locale exists");
+            let locale =
+                crate::Locale::FromULoc(uloc::ULoc::try_from(test.locale).expect("locale exists"));
             let plr = super::PluralRules::try_new(locale, test.clone().opts)?;
             let actual = test
                 .numbers

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.2", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.4.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -70,10 +70,3 @@ icu_version_67_plus = [
   "rust_icu_umsg/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_uloc/use_ecma402",
-  "rust_icu_umsg/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -40,7 +40,6 @@ icu_config = []
 icu_version_in_env = []
 icu_version_64_plus = []
 icu_version_67_plus = []
-use_ecma402 = []
 
 
 [badges]

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -66,12 +66,6 @@ use-bindgen = [
   "rust_icu_uloc/use-bindgen",
   "rust_icu_ustring/use-bindgen",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_uloc/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "google/rust_icu" }

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "rust_icu_ubrk"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -67,12 +67,6 @@ icu_version_67_plus = [
   "rust_icu_uenum/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_uenum/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -67,12 +67,6 @@ icu_version_67_plus = [
   "rust_icu_uenum/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_uenum/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.4.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.4.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -77,14 +77,6 @@ icu_version_67_plus = [
   "rust_icu_uloc/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_ucal/use_ecma402",
-  "rust_icu_uenum/use_ecma402",
-  "rust_icu_uloc/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -37,10 +37,6 @@ icu_version_67_plus = [
   "rust_icu_common/icu_version_67_plus",
   "rust_icu_sys/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -36,10 +36,6 @@ icu_version_67_plus = [
   "rust_icu_common/icu_version_67_plus",
   "rust_icu_sys/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uformattable"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,9 +18,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -60,11 +60,6 @@ icu_version_67_plus = [
   "rust_icu_sys/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,9 +18,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -60,11 +60,6 @@ icu_version_67_plus = [
   "rust_icu_sys/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -19,10 +19,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -23,7 +23,6 @@ rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-feat
 rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
 rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.2", default-features = false }
 rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
-ecma402_traits = { path = "../ecma402_traits", version = "0.2.0", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.25"
@@ -67,13 +66,6 @@ icu_version_67_plus = [
   "rust_icu_sys/icu_version_67_plus",
   "rust_icu_uenum/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
-]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_uenum/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-  "ecma402_traits",
 ]
 
 [build-dependencies]

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -28,9 +28,6 @@ use {
     },
 };
 
-#[cfg(feature="use_ecma402")]
-use ecma402_traits;
-
 /// Maximum length of locale supported by uloc.h.
 /// See `ULOC_FULLNAME_CAPACITY`.
 const LOCALE_CAPACITY: usize = 158;
@@ -55,9 +52,6 @@ impl fmt::Display for ULoc {
         write!(f, "{}", self.repr)
     }
 }
-/// Marker implementation for ULoc.
-#[cfg(feature="use_ecma402")]
-impl ecma402_traits::Locale for ULoc {}
 
 impl TryFrom<&str> for ULoc {
     type Error = common::Error;

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -68,12 +68,6 @@ icu_version_67_plus = [
   "rust_icu_uloc/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_uloc/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.3.2", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.4.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -74,13 +74,6 @@ icu_version_67_plus = [
   "rust_icu_uloc/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_uformattable/use_ecma402",
-  "rust_icu_uloc/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,11 +18,11 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "0.3.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "0.4.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unumberformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.1"
+version = "0.4.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -19,12 +19,12 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.1", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "0.3.1", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.3.1", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "0.3.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "0.4.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.4.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -81,14 +81,6 @@ icu_version_67_plus = [
   "rust_icu_unum/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_uformattable/use_ecma402",
-  "rust_icu_uloc/use_ecma402",
-  "rust_icu_unum/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -67,12 +67,6 @@ icu_version_67_plus = [
   "rust_icu_uenum/icu_version_67_plus",
   "rust_icu_ustring/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_uenum/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -37,8 +37,4 @@ icu_version_67_plus = [
   "rust_icu_common/icu_version_67_plus",
   "rust_icu_sys/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-]
 

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -36,10 +36,6 @@ icu_version_67_plus = [
   "rust_icu_common/icu_version_67_plus",
   "rust_icu_sys/icu_version_67_plus",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -67,12 +67,6 @@ use-bindgen = [
   "rust_icu_uenum/use-bindgen",
   "rust_icu_ustring/use-bindgen",
 ]
-use_ecma402 = [
-  "rust_icu_common/use_ecma402",
-  "rust_icu_sys/use_ecma402",
-  "rust_icu_uenum/use_ecma402",
-  "rust_icu_ustring/use_ecma402",
-]
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "google/rust_icu" }

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "rust_icu_utrans"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.3.2"
+version = "0.4.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,10 +19,10 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.3.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.3.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.3.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.3.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "0.4.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.4.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"


### PR DESCRIPTION
In retrospect, the introduction of the feature was unnecessary.  Instead
of requiring upstream libraries to implement marker interfaces, the
implementation is lifted into the ECMA402 implementation.

This allows rust_icu to continue being independent of ECMA402 traits,
while we're still able to build ECMA402 compatible APIs on top.