### PR TITLE
Compile on stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,18 +154,9 @@ Feature              | Default? | Description
     Install from https://rustup.rs. Used to set toolchain defaults. This will
     install `cargo` as well.
 
-*   `rust` nightly toolchain
+* Clang
 
-    Two options exist here:
-
-    1.  Set the global default: `rustup toolchain set nightly`
-
-    2.  Set the default toolchain just for `rust_icu`. Go to the directory you
-        cloned `rust_icu` into, then issue:
-
-    ```
-    rustup override set nightly
-    ```
+    You must have [Clang](https://clang.llvm.org/) installed to access the right headers.
 
 *   The ICU library development environmnet
 

--- a/rust_icu_common/src/lib.rs
+++ b/rust_icu_common/src/lib.rs
@@ -494,6 +494,11 @@ impl CStringVec {
     pub fn len(&self) -> usize {
         self.rep.len()
     }
+
+    /// Returns whether the vector is empty.
+    pub fn is_empty(&self) -> bool {
+        self.rep.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -546,11 +551,7 @@ mod tests {
             },
         ];
         for test in tests {
-            assert!(
-                parse_ok(test.clone()).is_ok(),
-                "for test: {:?}",
-                test.clone()
-            );
+            assert!(parse_ok(test).is_ok(), "for test: {:?}", test.clone());
         }
     }
 
@@ -577,11 +578,7 @@ mod tests {
             },
         ];
         for test in tests {
-            assert!(
-                parse_ok(test.clone()).is_err(),
-                "for test: {:?}",
-                test.clone()
-            );
+            assert!(parse_ok(test).is_err(), "for test: {:?}", test.clone());
         }
     }
 }

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -1,4 +1,3 @@
-#![feature(try_trait)]
 // Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -149,7 +148,7 @@ mod inner {
                 .output()
                 .with_context(|| format!("could not execute command: {}", self.name))?;
             let result = String::from_utf8(output.stdout)
-                .with_context(|| format!("could not convert output to UTF8"))?;
+                .with_context(|| "could not convert output to UTF8")?;
             Ok(result.trim().to_string())
         }
     }
@@ -170,14 +169,14 @@ mod inner {
         fn prefix(&mut self) -> Result<String> {
             self.rep
                 .run(&["--variable=prefix", "icu-i18n"])
-                .with_context(|| format!("could not get config prefix"))
+                .with_context(|| "could not get config prefix")
         }
 
         /// Obtains the default library path for the libraries.
         fn libdir(&mut self) -> Result<String> {
             self.rep
                 .run(&["--variable=libdir", "icu-i18n"])
-                .with_context(|| format!("could not get library directory"))
+                .with_context(|| "could not get library directory")
         }
 
         /// Obtains the needed flags for the linker.
@@ -186,7 +185,7 @@ mod inner {
             let result = self
                 .rep
                 .run(&["--libs", "icu-i18n"])
-                .with_context(|| format!("could not get the ld flags"))?;
+                .with_context(|| "could not get the ld flags")?;
             Ok(result.replace("-L", "-L ").replace("-l", "-l "))
         }
 
@@ -194,14 +193,14 @@ mod inner {
         fn cppflags(&mut self) -> Result<String> {
             self.rep
                 .run(&["--cflags", "icu-i18n"])
-                .with_context(|| format!("while getting the cpp flags"))
+                .with_context(|| "while getting the cpp flags")
         }
 
         /// Obtains the major-minor version number for the library. Returns a string like `64.2`.
         fn version(&mut self) -> Result<String> {
             self.rep
                 .run(&["--modversion", "icu-i18n"])
-                .with_context(|| format!("while getting ICU version; is icu-config in $PATH?"))
+                .with_context(|| "while getting ICU version; is icu-config in $PATH?")
         }
 
         fn install_dir(&mut self) -> Result<String> {
@@ -212,7 +211,7 @@ mod inner {
         /// version "64.2"
         fn version_major() -> Result<String> {
             let version = ICUConfig::new().version()?;
-            let components = version.split(".");
+            let components = version.split('.');
             let last = components
                 .take(1)
                 .last()
@@ -238,7 +237,7 @@ mod inner {
     /// the full path of the generated wrapper header file.
     fn generate_wrapper_header(
         out_dir_path: &Path,
-        bindgen_source_modules: &Vec<&str>,
+        bindgen_source_modules: &[&str],
         include_path: &Path,
     ) -> String {
         let wrapper_path = out_dir_path.join("wrapper.h");
@@ -248,6 +247,7 @@ mod inner {
             .unwrap();
         let includes = bindgen_source_modules
             .iter()
+            .copied()
             .map(|f| {
                 let file_path = include_path.join(format!("{}.h", f));
                 let file_path_str = format!("#include \"{}\"\n", file_path.to_str().unwrap());
@@ -314,7 +314,7 @@ mod inner {
         let output_file = output_file_path.to_str().unwrap();
         bindings
             .write_to_file(output_file)
-            .with_context(|| format!("while writing output"))?;
+            .with_context(|| "while writing output")?;
         Ok(())
     }
 
@@ -364,7 +364,7 @@ macro_rules! versioned_function {{
             );
             macro_file
                 .write_all(&to_write.into_bytes())
-                .with_context(|| format!("while writing macros.rs with renaming"))
+                .with_context(|| "while writing macros.rs with renaming")
         } else {
             // The library names have not been renamed, generating an empty macro
             println!("renaming: false");
@@ -385,23 +385,23 @@ macro_rules! versioned_function {{
                     .to_string()
                     .into_bytes(),
                 )
-                .with_context(|| format!("while writing macros.rs without renaming"))
+                .with_context(|| "while writing macros.rs without renaming")
         }
     }
 
     /// Copies the featuers set in `Cargo.toml` into the build script.  Not sure
     /// why, but the features seem *ignored* when `build.rs` is used.
     pub fn copy_features() -> Result<()> {
-        if let Some(_) = env::var_os("CARGO_FEATURE_RENAMING") {
+        if env::var_os("CARGO_FEATURE_RENAMING").is_some() {
             println!("cargo:rustc-cfg=feature=\"renaming\"");
         }
-        if let Some(_) = env::var_os("CARGO_FEATURE_USE_BINDGEN") {
+        if env::var_os("CARGO_FEATURE_USE_BINDGEN").is_some() {
             println!("cargo:rustc-cfg=feature=\"use-bindgen\"");
         }
-        if let Some(_) = env::var_os("CARGO_FEATURE_ICU_CONFIG") {
+        if env::var_os("CARGO_FEATURE_ICU_CONFIG").is_some() {
             println!("cargo:rustc-cfg=feature=\"icu_config\"");
         }
-        if let Some(_) = env::var_os("CARGO_FEATURE_ICU_VERSION_IN_ENV") {
+        if env::var_os("CARGO_FEATURE_ICU_VERSION_IN_ENV").is_some() {
             println!("cargo:rustc-cfg=feature=\"icu_version_in_env\"");
         }
         let version_major = ICUConfig::version_major_int()?;
@@ -435,8 +435,8 @@ macro_rules! versioned_function {{
         let header_file =
             generate_wrapper_header(&out_dir_path, &BINDGEN_SOURCE_MODULES, &include_dir_path);
         run_bindgen(&header_file, out_dir_path)
-            .with_context(|| format!("while running bindgen"))?;
-        run_renamegen(out_dir_path).with_context(|| format!("while running renamegen"))?;
+            .with_context(|| "while running bindgen")?;
+        run_renamegen(out_dir_path).with_context(|| "while running renamegen")?;
 
         println!("cargo:install-dir={}", ICUConfig::new().install_dir()?);
 
@@ -452,7 +452,7 @@ macro_rules! versioned_function {{
 fn main() -> Result<(), anyhow::Error> {
     std::env::set_var("RUST_BACKTRACE", "full");
     inner::copy_features()?;
-    if let None = std::env::var_os("CARGO_FEATURE_ICU_CONFIG") {
+    if std::env::var_os("CARGO_FEATURE_ICU_CONFIG").is_none() {
         return Ok(());
     }
     inner::icu_config_autodetect()?;

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -434,8 +434,7 @@ macro_rules! versioned_function {{
 
         let header_file =
             generate_wrapper_header(&out_dir_path, &BINDGEN_SOURCE_MODULES, &include_dir_path);
-        run_bindgen(&header_file, out_dir_path)
-            .with_context(|| "while running bindgen")?;
+        run_bindgen(&header_file, out_dir_path).with_context(|| "while running bindgen")?;
         run_renamegen(out_dir_path).with_context(|| "while running renamegen")?;
 
         println!("cargo:install-dir={}", ICUConfig::new().install_dir()?);

--- a/rust_icu_ucal/src/lib.rs
+++ b/rust_icu_ucal/src/lib.rs
@@ -57,7 +57,7 @@ impl UCalendar {
         cal_type: sys::UCalendarType,
     ) -> Result<UCalendar, common::Error> {
         let mut status = common::Error::OK_CODE;
-        let asciiz_locale = ffi::CString::new(locale).map_err(|e| common::Error::wrapper(e))?;
+        let asciiz_locale = ffi::CString::new(locale).map_err(common::Error::wrapper)?;
         // Requires that zone_id contains a valid Unicode character representation with known
         // beginning and length.  asciiz_locale must be a pointer to a valid C string.  The first
         // condition is assumed to be satisfied by ustring::UChar, and the second should be
@@ -223,7 +223,7 @@ pub fn get_default_time_zone() -> Result<String, common::Error> {
     // Preflight the time zone first.
     let time_zone_length = unsafe {
         assert!(common::Error::is_ok(status));
-        versioned_function!(ucal_getDefaultTimeZone)(0 as *mut sys::UChar, 0, &mut status)
+        versioned_function!(ucal_getDefaultTimeZone)(std::ptr::null_mut(), 0, &mut status)
     } as usize;
     common::Error::ok_preflight(status)?;
 

--- a/rust_icu_udat/build.rs
+++ b/rust_icu_udat/build.rs
@@ -1,4 +1,3 @@
-#![feature(try_trait)]
 // Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +55,7 @@ mod inner {
                 .output()
                 .with_context(|| format!("could not execute command: {}", self.name))?;
             let result = String::from_utf8(output.stdout)
-                .with_context(|| format!("could not convert output to UTF8"))?;
+                .with_context(|| "could not convert output to UTF8")?;
             Ok(result.trim().to_string())
         }
     }
@@ -77,14 +76,14 @@ mod inner {
         pub fn version(&mut self) -> Result<String> {
             self.rep
                 .run(&["--modversion", "icu-i18n"])
-                .with_context(|| format!("while getting ICU version; is icu-config in $PATH?"))
+                .with_context(|| "while getting ICU version; is icu-config in $PATH?")
         }
 
         /// Returns the config major number.  For example, will return "64" for
         /// version "64.2"
         pub fn version_major() -> Result<String> {
             let version = ICUConfig::new().version()?;
-            let components = version.split(".");
+            let components = version.split('.');
             let last = components
                 .take(1)
                 .last()

--- a/rust_icu_uenum/src/lib.rs
+++ b/rust_icu_uenum/src/lib.rs
@@ -75,7 +75,7 @@ impl TryFrom<&[&str]> for Enumeration {
         // https://unicode-org.atlassian.net/browse/ICU-20918
         assert!(!rep.is_null());
         Ok(Enumeration {
-            rep: rep,
+            rep,
             raw: Some(raw),
         })
     }
@@ -257,7 +257,7 @@ mod tests {
         let mut results = vec![];
         for result in e {
             let elem = result.expect("no error");
-            count = count + 1;
+            count += 1;
             results.push(elem);
         }
         assert_eq!(count, 3, "results: {:?}", results);

--- a/rust_icu_uloc/build.rs
+++ b/rust_icu_uloc/build.rs
@@ -1,4 +1,3 @@
-#![feature(try_trait)]
 // Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +55,7 @@ mod inner {
                 .output()
                 .with_context(|| format!("could not execute command: {}", self.name))?;
             let result = String::from_utf8(output.stdout)
-                .with_context(|| format!("could not convert output to UTF8"))?;
+                .with_context(|| "could not convert output to UTF8")?;
             Ok(result.trim().to_string())
         }
     }
@@ -77,14 +76,14 @@ mod inner {
         pub fn version(&mut self) -> Result<String> {
             self.rep
                 .run(&["--modversion", "icu-i18n"])
-                .with_context(|| format!("while getting ICU version; is icu-config in $PATH?"))
+                .with_context(|| "while getting ICU version; is icu-config in $PATH?")
         }
 
         /// Returns the config major number.  For example, will return "64" for
         /// version "64.2"
         pub fn version_major() -> Result<String> {
             let version = ICUConfig::new().version()?;
-            let components = version.split(".");
+            let components = version.split('.');
             let last = components
                 .take(1)
                 .last()

--- a/rust_icu_ustring/src/lib.rs
+++ b/rust_icu_ustring/src/lib.rs
@@ -158,7 +158,7 @@ impl TryFrom<&str> for crate::UChar {
         unsafe {
             assert!(common::Error::is_ok(status));
             versioned_function!(u_strFromUTF8)(
-                0 as *mut sys::UChar,
+                std::ptr::null_mut(),
                 0,
                 &mut dest_length,
                 rust_string.as_ptr() as *const raw::c_char,
@@ -207,7 +207,7 @@ impl TryFrom<&UChar> for String {
         unsafe {
             assert!(common::Error::is_ok(status));
             versioned_function!(u_strToUTF8)(
-                0 as *mut raw::c_char,
+                std::ptr::null_mut(),
                 0,
                 &mut dest_length,
                 u.rep.as_ptr(),
@@ -276,6 +276,10 @@ impl crate::UChar {
     /// Does *not* take ownership of the buffer that was passed in.
     ///
     /// **DO NOT USE UNLESS YOU HAVE NO OTHER CHOICE.**
+    ///
+    /// # Safety
+    ///
+    /// `rep` must point to an initialized sequence of at least `len` `UChar`s.
     pub unsafe fn clone_from_raw_parts(rep: *mut sys::UChar, len: i32) -> crate::UChar {
         assert!(len >= 0);
         // Always works for len: i32 >= 0.
@@ -307,6 +311,11 @@ impl crate::UChar {
     /// Returns the length of the string, in code points.
     pub fn len(&self) -> usize {
         self.rep.len()
+    }
+
+    /// Returns whether the string is empty.
+    pub fn is_empty(&self) -> bool {
+        self.rep.is_empty()
     }
 
     /// Returns the underlying representation as a mutable C representation.  Caller MUST ensure


### PR DESCRIPTION
This PR allows `rust_icu` to compile using stable Rust by removing the unused `#![feature(try_trait)]` attributes in the `build.rs`s. I also fixed a couple Clippy warnings there and documented the dependency on Clang (I didn't have Clang installed and compilation failed as it couldn't find `stddef.h`.