### PR TITLE
fix: run `cargo fmt` at the top of the tree

### DIFF
--- a/ecma402_traits/src/datetimeformat.rs
+++ b/ecma402_traits/src/datetimeformat.rs
@@ -128,7 +128,7 @@ pub mod options {
         /// 4 hour cycle, 0..23.
         H23,
         /// 4 hour cycle, 1..24.
-        H24
+        H24,
     }
 
     #[derive(Eq, PartialEq, Debug, Clone)]
@@ -224,7 +224,7 @@ pub struct DateTimeFormatOptions {
 
 impl Default for DateTimeFormatOptions {
     fn default() -> Self {
-        Self{
+        Self {
             date_style: options::Style::Long,
             time_style: options::Style::Long,
             fractional_second_digits: 2,

--- a/rust_icu_common/src/lib.rs
+++ b/rust_icu_common/src/lib.rs
@@ -310,10 +310,10 @@ macro_rules! buffered_string_method_with_retry {
 ///
 /// ```c++ ignore
 /// int32_t unum_formatDouble(
-///     const UNumberFormat* fmt, 
-///     double number, 
-///     UChar* result, 
-///     int32_t result_length, 
+///     const UNumberFormat* fmt,
+///     double number,
+///     UChar* result,
+///     int32_t result_length,
 ///     UFieldPosition* pos,
 ///     UErrorCode *status)
 /// ```
@@ -387,7 +387,7 @@ macro_rules! format_ustring_for_type{
 /// );
 /// ```
 ///
-/// which then becomes: 
+/// which then becomes:
 ///
 /// ```rust ignore
 /// impl _ {
@@ -436,7 +436,7 @@ macro_rules! generalized_fallible_getter{
 /// );
 /// ```
 ///
-/// which then becomes: 
+/// which then becomes:
 ///
 /// ```rust ignore
 /// impl _ {

--- a/rust_icu_ecma402/src/lib.rs
+++ b/rust_icu_ecma402/src/lib.rs
@@ -40,7 +40,7 @@ impl std::fmt::Display for Locale {
     /// `rust_icu` implementation.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Locale::FromULoc(ref l) =>  write!(f, "{}", l),
+            Locale::FromULoc(ref l) => write!(f, "{}", l),
         }
     }
 }

--- a/rust_icu_sys/src/lib.rs
+++ b/rust_icu_sys/src/lib.rs
@@ -20,32 +20,49 @@
     unused_imports
 )]
 
-#[cfg(all(feature="icu_version_in_env", feature="icu_config"))]
+#[cfg(all(feature = "icu_version_in_env", feature = "icu_config"))]
 compile_error!(
-    "Features `icu_version_in_env` and `icu_config` are not compatible." +
-    " Choose at most one of them.");
+    "Features `icu_version_in_env` and `icu_config` are not compatible."
+        + " Choose at most one of them."
+);
 
-#[cfg(all(feature="icu_config", not(feature="use-bindgen")))]
+#[cfg(all(feature = "icu_config", not(feature = "use-bindgen")))]
 compile_error!("Feature `icu_config` is useless without the feature `use-bindgen`");
 
 // This feature combination is not inherrently a problem; we had no use case that
 // required it just yet.
-#[cfg(all(not(feature="renaming"), not(feature="use-bindgen")))]
+#[cfg(all(not(feature = "renaming"), not(feature = "use-bindgen")))]
 compile_error!("You must use `renaming` when not using `use-bindgen`");
 
-#[cfg(feature="use-bindgen")]
+#[cfg(feature = "use-bindgen")]
 include!(concat!(env!("OUT_DIR"), "/macros.rs"));
-#[cfg(all(feature="use-bindgen",feature="icu_config",not(feature="icu_version_in_env")))]
+#[cfg(all(
+    feature = "use-bindgen",
+    feature = "icu_config",
+    not(feature = "icu_version_in_env")
+))]
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
-#[cfg(not(feature="use-bindgen"))]
+#[cfg(not(feature = "use-bindgen"))]
 include!("../bindgen/macros.rs");
 
-#[cfg(all(not(feature="use-bindgen"),not(feature="icu_version_in_env"),not(feature="icu_config")))]
+#[cfg(all(
+    not(feature = "use-bindgen"),
+    not(feature = "icu_version_in_env"),
+    not(feature = "icu_config")
+))]
 include!("../bindgen/lib.rs");
 
-#[cfg(all(not(feature="use-bindgen"),feature="icu_version_in_env",not(feature="icu_config")))]
-include!(concat!("../bindgen/lib_", env!("RUST_ICU_MAJOR_VERSION_NUMBER"), ".rs"));
+#[cfg(all(
+    not(feature = "use-bindgen"),
+    feature = "icu_version_in_env",
+    not(feature = "icu_config")
+))]
+include!(concat!(
+    "../bindgen/lib_",
+    env!("RUST_ICU_MAJOR_VERSION_NUMBER"),
+    ".rs"
+));
 
 // Add the ability to print the error code, so that it can be reported in
 // aggregated errors.
@@ -62,4 +79,3 @@ extern crate libc;
 #[link(name = "icui18n", kind = "dylib")]
 #[link(name = "icuuc", kind = "dylib")]
 extern "C" {}
-

--- a/rust_icu_ubrk/src/lib.rs
+++ b/rust_icu_ubrk/src/lib.rs
@@ -132,8 +132,7 @@ impl Iterator for UBreakIterator {
     /// [`preceding`]: #method.preceding
     /// [`previous`]: #method.previous
     fn next(&mut self) -> Option<Self::Item> {
-        let index =
-            unsafe { versioned_function!(ubrk_next)(self.rep.as_ptr()) };
+        let index = unsafe { versioned_function!(ubrk_next)(self.rep.as_ptr()) };
         if index == UBRK_DONE {
             None
         } else {
@@ -205,10 +204,7 @@ impl UBreakIterator {
     /// for rules syntax.
     ///
     /// Implements `ubrk_openRules`.
-    pub fn try_new_rules(
-        rules: &str,
-        text: &str,
-    ) -> Result<Self, common::Error> {
+    pub fn try_new_rules(rules: &str, text: &str) -> Result<Self, common::Error> {
         let rules = ustring::UChar::try_from(rules)?;
         let text = ustring::UChar::try_from(text)?;
         Self::try_new_rules_ustring(&rules, &text)
@@ -254,10 +250,7 @@ impl UBreakIterator {
     /// [`get_binary_rules`]: #method.get_binary_rules
     ///
     /// Implements `ubrk_openBinaryRules`.
-    pub fn try_new_binary_rules(
-        rules: &Vec<u8>,
-        text: &str,
-    ) -> Result<Self, common::Error> {
+    pub fn try_new_binary_rules(rules: &Vec<u8>, text: &str) -> Result<Self, common::Error> {
         let text = ustring::UChar::try_from(text)?;
         Self::try_new_binary_rules_ustring(rules, &text)
     }
@@ -369,10 +362,7 @@ impl UBreakIterator {
     }
 
     /// Implements `ubrk_setText`.
-    pub fn set_text_ustring(
-        &mut self,
-        text: &ustring::UChar,
-    ) -> Result<(), common::Error> {
+    pub fn set_text_ustring(&mut self, text: &ustring::UChar) -> Result<(), common::Error> {
         let mut status = common::Error::OK_CODE;
         // Clone text and take ownership.
         let text = text.clone();
@@ -402,8 +392,7 @@ impl UBreakIterator {
     ///
     /// Implements `ubrk_previous`.
     pub fn previous(&self) -> Option<i32> {
-        let result =
-            unsafe { versioned_function!(ubrk_previous)(self.rep.as_ptr()) };
+        let result = unsafe { versioned_function!(ubrk_previous)(self.rep.as_ptr()) };
         if result == UBRK_DONE {
             None
         } else {
@@ -435,9 +424,7 @@ impl UBreakIterator {
     ///
     /// Implements `ubrk_preceding`.
     pub fn preceding(&self, offset: i32) -> i32 {
-        unsafe {
-            versioned_function!(ubrk_preceding)(self.rep.as_ptr(), offset)
-        }
+        unsafe { versioned_function!(ubrk_preceding)(self.rep.as_ptr(), offset) }
     }
 
     /// Moves the iterator to the boundary immediately following the specified offset
@@ -445,18 +432,15 @@ impl UBreakIterator {
     ///
     /// Implements `ubrk_following`.
     pub fn following(&self, offset: i32) -> i32 {
-        unsafe {
-            versioned_function!(ubrk_following)(self.rep.as_ptr(), offset)
-        }
+        unsafe { versioned_function!(ubrk_following)(self.rep.as_ptr(), offset) }
     }
 
     /// Reports whether the specified offset is a boundary.
     ///
     /// Implements `ubrk_isBoundary`.
     pub fn is_boundary(&self, offset: i32) -> bool {
-        let result: sys::UBool = unsafe {
-            versioned_function!(ubrk_isBoundary)(self.rep.as_ptr(), offset)
-        };
+        let result: sys::UBool =
+            unsafe { versioned_function!(ubrk_isBoundary)(self.rep.as_ptr(), offset) };
         result != 0
     }
 
@@ -470,11 +454,7 @@ impl UBreakIterator {
         let mut status = common::Error::OK_CODE;
         let char_ptr = unsafe {
             assert!(common::Error::is_ok(status));
-            versioned_function!(ubrk_getLocaleByType)(
-                self.rep.as_ptr(),
-                type_,
-                &mut status,
-            )
+            versioned_function!(ubrk_getLocaleByType)(self.rep.as_ptr(), type_, &mut status)
         };
         common::Error::ok_or_warning(status)?;
         let c_str = unsafe { ffi::CStr::from_ptr(char_ptr) };
@@ -549,8 +529,7 @@ impl Iterator for Locales {
         if self.index >= self.upper {
             return None;
         }
-        let loc_ptr =
-            unsafe { versioned_function!(ubrk_getAvailable)(self.index) };
+        let loc_ptr = unsafe { versioned_function!(ubrk_getAvailable)(self.index) };
         assert_ne!(loc_ptr, 0 as *const raw::c_char);
         let c_str = unsafe { ffi::CStr::from_ptr(loc_ptr) };
         let loc = uloc::ULoc::try_from(c_str);
@@ -602,21 +581,16 @@ mod tests {
         fn next(&mut self) -> Option<Self::Item> {
             let start = self.iter.current();
             self.iter.next().and_then(|end| {
-                String::from_utf16(
-                    &self.chars[(start as usize)..(end as usize)],
-                )
-                .ok()
+                String::from_utf16(&self.chars[(start as usize)..(end as usize)]).ok()
             })
         }
     }
 
-    const TEXT: &str =
-        r#""It wasn't the wine," murmured Mr. Snodgrass. "It was the salmon.""#;
+    const TEXT: &str = r#""It wasn't the wine," murmured Mr. Snodgrass. "It was the salmon.""#;
 
     #[test]
     fn test_iteration() {
-        let mut break_iter =
-            UBreakIterator::try_new(UBRK_WORD, "en", TEXT).unwrap();
+        let mut break_iter = UBreakIterator::try_new(UBRK_WORD, "en", TEXT).unwrap();
 
         assert!(break_iter.is_boundary(0));
         assert_eq!(0, break_iter.first());
@@ -690,9 +664,7 @@ mod tests {
         let iter1_binary_rules = iter1.get_binary_rules().unwrap();
         let iter1_boundaries: Vec<i32> = iter1.collect();
 
-        let iter2 =
-            UBreakIterator::try_new_binary_rules(&iter1_binary_rules, TEXT)
-                .unwrap();
+        let iter2 = UBreakIterator::try_new_binary_rules(&iter1_binary_rules, TEXT).unwrap();
         let iter2_boundaries: Vec<i32> = iter2.collect();
 
         assert!(!iter2_boundaries.is_empty());
@@ -713,8 +685,7 @@ $not_w = [^w];
 $not_w+;  # No breaks between code points other than `w`.
 $w+ {99}; # Break on `w`s with custom rule status of `99`.
 "#;
-        let mut break_iter =
-            UBreakIterator::try_new_rules(rules, TEXT).unwrap();
+        let mut break_iter = UBreakIterator::try_new_rules(rules, TEXT).unwrap();
 
         #[derive(Debug)]
         struct TestCase {
@@ -837,23 +808,15 @@ $w+ {99}; # Break on `w`s with custom rule status of `99`.
 
     #[test]
     fn test_get_locale_by_type() {
-        let iter =
-            UBreakIterator::try_new(UBRK_WORD, "en_US_CA@lb=strict", TEXT)
-                .unwrap();
+        let iter = UBreakIterator::try_new(UBRK_WORD, "en_US_CA@lb=strict", TEXT).unwrap();
 
         // The "valid locale" is the most specific locale supported by ICU, given
         // what was requested.
-        assert_eq!(
-            "en_US",
-            iter.get_locale_by_type(ULOC_VALID_LOCALE).unwrap(),
-        );
+        assert_eq!("en_US", iter.get_locale_by_type(ULOC_VALID_LOCALE).unwrap(),);
 
         // The "actual locale" is the locale that breaking information actually comes from.
         // In most cases this will be "root".
-        assert_eq!(
-            "root",
-            iter.get_locale_by_type(ULOC_ACTUAL_LOCALE).unwrap(),
-        );
+        assert_eq!("root", iter.get_locale_by_type(ULOC_ACTUAL_LOCALE).unwrap(),);
     }
 
     #[test]

--- a/rust_icu_ucol/src/lib.rs
+++ b/rust_icu_ucol/src/lib.rs
@@ -267,11 +267,25 @@ mod tests {
     #[test]
     fn attribute_setter() {
         let collator = crate::UCollator::try_from("sr-Latn").unwrap();
-        collator.set_attribute(sys::UColAttribute::UCOL_CASE_FIRST, sys::UColAttributeValue::UCOL_OFF).unwrap();
-        let attr = collator.get_attribute(sys::UColAttribute::UCOL_CASE_FIRST).unwrap();
+        collator
+            .set_attribute(
+                sys::UColAttribute::UCOL_CASE_FIRST,
+                sys::UColAttributeValue::UCOL_OFF,
+            )
+            .unwrap();
+        let attr = collator
+            .get_attribute(sys::UColAttribute::UCOL_CASE_FIRST)
+            .unwrap();
         assert_eq!(sys::UColAttributeValue::UCOL_OFF, attr);
-        collator.set_attribute(sys::UColAttribute::UCOL_CASE_FIRST, sys::UColAttributeValue::UCOL_LOWER_FIRST).unwrap();
-        let attr = collator.get_attribute(sys::UColAttribute::UCOL_CASE_FIRST).unwrap();
+        collator
+            .set_attribute(
+                sys::UColAttribute::UCOL_CASE_FIRST,
+                sys::UColAttributeValue::UCOL_LOWER_FIRST,
+            )
+            .unwrap();
+        let attr = collator
+            .get_attribute(sys::UColAttribute::UCOL_CASE_FIRST)
+            .unwrap();
         assert_eq!(sys::UColAttributeValue::UCOL_LOWER_FIRST, attr);
     }
 }

--- a/rust_icu_udat/src/lib.rs
+++ b/rust_icu_udat/src/lib.rs
@@ -365,7 +365,11 @@ mod tests {
 
             let fmt = fmt;
             let actual = fmt.format(t.date)?;
-            assert_eq!(actual, t.expected, "(left==actual; right==expected)\n\ttest: {:?}", t);
+            assert_eq!(
+                actual, t.expected,
+                "(left==actual; right==expected)\n\ttest: {:?}",
+                t
+            );
         }
         Ok(())
     }

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -15,16 +15,15 @@
 use {
     rust_icu_common as common,
     rust_icu_common::buffered_string_method_with_retry,
+    rust_icu_sys as sys,
     rust_icu_sys::versioned_function,
     rust_icu_sys::*,
-    rust_icu_sys as sys,
     rust_icu_uenum::Enumeration,
     std::{
         cmp::Ordering,
         convert::{From, TryFrom, TryInto},
-        ffi,
+        ffi, fmt,
         os::raw,
-        fmt,
     },
 };
 
@@ -669,7 +668,7 @@ mod tests {
     }
 
     // This tests verifies buggy behavior which is fixed since ICU version 67.1
-    #[cfg(not(feature="icu_version_67_plus"))]
+    #[cfg(not(feature = "icu_version_67_plus"))]
     #[test]
     fn test_accept_language_exact_match() {
         let accept_list: Result<Vec<_>, _> = vec!["es_ES", "ar_EG", "fr_FR"]
@@ -695,7 +694,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature="icu_version_67_plus")]
+    #[cfg(feature = "icu_version_67_plus")]
     #[test]
     fn test_accept_language_exact_match() {
         let accept_list: Result<Vec<_>, _> = vec!["es_ES", "ar_EG", "fr_FR"]

--- a/rust_icu_umsg/src/lib.rs
+++ b/rust_icu_umsg/src/lib.rs
@@ -89,8 +89,8 @@
 //! ```
 
 use {
-    rust_icu_common as common, rust_icu_sys as sys, rust_icu_sys::*,
-    rust_icu_uloc as uloc, rust_icu_ustring as ustring, std::convert::TryFrom,
+    rust_icu_common as common, rust_icu_sys as sys, rust_icu_sys::*, rust_icu_uloc as uloc,
+    rust_icu_ustring as ustring, std::convert::TryFrom,
 };
 
 /// The implementation of the ICU `UMessageFormat*`.
@@ -457,7 +457,8 @@ mod tests {
               Formatted integer: {1,number,integer},
               Formatted string: {2},
               Date: {3,date,full}",
-        ).unwrap();
+        )
+        .unwrap();
         let _fmt = crate::UMessageFormat::try_from(&msg, &loc).unwrap();
 
         // This is not allowed!

--- a/rust_icu_unumberformatter/src/lib.rs
+++ b/rust_icu_unumberformatter/src/lib.rs
@@ -23,8 +23,7 @@ use {
     rust_icu_sys as sys,
     rust_icu_sys::versioned_function,
     rust_icu_sys::*,
-    rust_icu_uloc as uloc, rust_icu_unum as unum,
-    rust_icu_ustring as ustring,
+    rust_icu_uloc as uloc, rust_icu_unum as unum, rust_icu_ustring as ustring,
     rust_icu_ustring::buffered_uchar_method_with_retry,
     std::{convert::TryFrom, convert::TryInto, ptr},
 };
@@ -197,7 +196,9 @@ impl UFormattedNumber {
     ///
     /// Implements `unumf_resultNextFieldPosition`. Since 0.3.1. All access is
     /// via iterators.
-    pub fn try_field_iter<'a>(&'a self) -> Result<unum::UFieldPositionIterator<'a, Self>, common::Error> {
+    pub fn try_field_iter<'a>(
+        &'a self,
+    ) -> Result<unum::UFieldPositionIterator<'a, Self>, common::Error> {
         let mut result = unum::UFieldPositionIterator::try_new_owned(self)?;
         let mut status = sys::UErrorCode::U_ZERO_ERROR;
         unsafe {
@@ -205,7 +206,7 @@ impl UFormattedNumber {
                 self.as_c_ptr(),
                 result.as_mut_ptr(),
                 &mut status,
-                )
+            )
         };
         common::Error::ok_or_warning(status)?;
         Ok(result)
@@ -259,7 +260,10 @@ mod testing {
     #[test]
     fn basic() {
         let fmt = super::UNumberFormatter::try_new(
-            "measure-unit/length-meter compact-long sign-always", "sr-RS").unwrap();
+            "measure-unit/length-meter compact-long sign-always",
+            "sr-RS",
+        )
+        .unwrap();
         let result = fmt.format_double(123456.7890).unwrap();
         let result_str: String = result.try_into().unwrap();
         assert_eq!("+123 хиљаде m", result_str);
@@ -280,35 +284,35 @@ mod testing {
             expected: &'static str,
         }
         let tests = vec![
-           TestCase{
-               locale: "sr-RS",
-               number: 123456.7890,
-               skeleton: "measure-unit/length-meter compact-long sign-always",
-               expected: "+123 хиљаде m",
-           },
-           TestCase{
-               locale: "sr-RS-u-nu-deva",
-               number: 123456.7890,
-               skeleton: "measure-unit/length-meter compact-long sign-always",
-               expected: "+१२३ хиљаде m",
-           },
-           TestCase{
-               locale: "sr-RS",
-               number: 123456.7890,
-               skeleton: "numbering-system/deva",
-               expected: "१२३.४५६,७८९",
-           },
-           TestCase{
-               locale: "en-IN",
-               number: 123456.7890,
-               skeleton: "@@@",
-               expected: "1,23,000",
-           },
+            TestCase {
+                locale: "sr-RS",
+                number: 123456.7890,
+                skeleton: "measure-unit/length-meter compact-long sign-always",
+                expected: "+123 хиљаде m",
+            },
+            TestCase {
+                locale: "sr-RS-u-nu-deva",
+                number: 123456.7890,
+                skeleton: "measure-unit/length-meter compact-long sign-always",
+                expected: "+१२३ хиљаде m",
+            },
+            TestCase {
+                locale: "sr-RS",
+                number: 123456.7890,
+                skeleton: "numbering-system/deva",
+                expected: "१२३.४५६,७८९",
+            },
+            TestCase {
+                locale: "en-IN",
+                number: 123456.7890,
+                skeleton: "@@@",
+                expected: "1,23,000",
+            },
         ];
 
         for test in tests {
-            let fmt = super::UNumberFormatter::try_new(
-                &test.skeleton, &test.locale).expect(&format!("for test {:?}", &test));
+            let fmt = super::UNumberFormatter::try_new(&test.skeleton, &test.locale)
+                .expect(&format!("for test {:?}", &test));
             let result = fmt.format_double(test.number).unwrap();
             let result_str: String = result.try_into().unwrap();
             assert_eq!(test.expected, result_str, "for test {:?}", &test);

--- a/rust_icu_ustring/src/lib.rs
+++ b/rust_icu_ustring/src/lib.rs
@@ -322,7 +322,6 @@ impl crate::UChar {
     pub fn resize(&mut self, new_size: usize) {
         self.rep.resize(new_size, 0);
     }
-
 }
 
 #[cfg(test)]

--- a/rust_icu_utrans/src/lib.rs
+++ b/rust_icu_utrans/src/lib.rs
@@ -108,10 +108,7 @@ impl UTransliterator {
         let mut status = common::Error::OK_CODE;
         unsafe {
             assert!(common::Error::is_ok(status));
-            versioned_function!(utrans_register)(
-                trans.rep.as_ptr(),
-                &mut status,
-            )
+            versioned_function!(utrans_register)(trans.rep.as_ptr(), &mut status)
         }
         common::Error::ok_or_warning(status)?;
         // ICU4C now owns the transliterator and is responsible for closing it,
@@ -170,15 +167,10 @@ impl UTransliterator {
     /// Implements `utrans_getUnicodeID`.
     pub fn get_id(&self) -> Result<String, common::Error> {
         let mut id_len: i32 = 0;
-        let rep = unsafe {
-            versioned_function!(utrans_getUnicodeID)(
-                self.rep.as_ptr(),
-                &mut id_len,
-            )
-        };
+        let rep =
+            unsafe { versioned_function!(utrans_getUnicodeID)(self.rep.as_ptr(), &mut id_len) };
         assert_ne!(rep, 0 as *const sys::UChar);
-        let id_buf =
-            unsafe { slice::from_raw_parts(rep, id_len as usize) }.to_vec();
+        let id_buf = unsafe { slice::from_raw_parts(rep, id_len as usize) }.to_vec();
         let id = ustring::UChar::from(id_buf);
         String::try_from(&id)
     }
@@ -192,10 +184,7 @@ impl UTransliterator {
         let mut status = common::Error::OK_CODE;
         let rep = unsafe {
             assert!(common::Error::is_ok(status));
-            versioned_function!(utrans_openInverse)(
-                self.rep.as_ptr(),
-                &mut status,
-            )
+            versioned_function!(utrans_openInverse)(self.rep.as_ptr(), &mut status)
         };
         common::Error::ok_or_warning(status)?;
         assert_ne!(rep, 0 as *mut sys::UTransliterator);
@@ -208,10 +197,7 @@ impl UTransliterator {
     /// expected by [`new`](#method.new).
     ///
     /// Implements `utrans_toRules`.
-    pub fn to_rules(
-        &self,
-        escape_unprintable: bool,
-    ) -> Result<String, common::Error> {
+    pub fn to_rules(&self, escape_unprintable: bool) -> Result<String, common::Error> {
         let mut status = common::Error::OK_CODE;
         // Preflight to determine length of rules text.
         let rules_len = unsafe {
@@ -249,10 +235,7 @@ impl UTransliterator {
     /// is cleared.
     ///
     /// Implements `utrans_setFilter`.
-    pub fn set_filter(
-        &mut self,
-        pattern: Option<&str>,
-    ) -> Result<(), common::Error> {
+    pub fn set_filter(&mut self, pattern: Option<&str>) -> Result<(), common::Error> {
         let pattern = match pattern {
             Some(s) => Some(ustring::UChar::try_from(s)?),
             None => None,
@@ -350,12 +333,7 @@ impl UTransliterator {
     /// Implements `utrans_unregisterID`.
     pub fn unregister(id: &str) -> Result<(), common::Error> {
         let id = ustring::UChar::try_from(id)?;
-        unsafe {
-            versioned_function!(utrans_unregisterID)(
-                id.as_c_ptr(),
-                id.len() as i32,
-            )
-        }
+        unsafe { versioned_function!(utrans_unregisterID)(id.as_c_ptr(), id.len() as i32) }
         Ok(())
     }
 }
@@ -389,8 +367,7 @@ mod tests {
 
     #[test]
     fn test_inverse() {
-        let trans =
-            UTransliterator::new("Latin-ASCII", None, DIR_FWD).unwrap();
+        let trans = UTransliterator::new("Latin-ASCII", None, DIR_FWD).unwrap();
         let inverse = trans.inverse().unwrap();
         assert_eq!(inverse.get_id().unwrap(), "ASCII-Latin");
     }
@@ -399,12 +376,10 @@ mod tests {
     fn test_rules_based() {
         let rules = "a <> xyz;";
 
-        let fwd_trans = UTransliterator::new("MyA-MyXYZ", Some(rules), DIR_FWD)
-            .unwrap();
+        let fwd_trans = UTransliterator::new("MyA-MyXYZ", Some(rules), DIR_FWD).unwrap();
         assert_eq!(fwd_trans.transliterate("abc").unwrap(), "xyzbc");
 
-        let rev_trans = UTransliterator::new("MyXYZ-MyA", Some(rules), DIR_REV)
-            .unwrap();
+        let rev_trans = UTransliterator::new("MyXYZ-MyA", Some(rules), DIR_REV).unwrap();
         assert_eq!(rev_trans.transliterate("xyzbc").unwrap(), "abc");
     }
 


### PR DESCRIPTION
Let's standardize the formatting to make new contributions easier.

For example, https://github.com/google/rust_icu/pull/187 would be
made smaller and would lose incidental formatting changes.