### PR TITLE
build: makes include dirs more precise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,10 @@ ICU_LIBDIR := $(shell icu-config --libdir)
 PKG_CONFIG_PATH := "${HOME}/local/lib/pkgconfig:${PKG_CONFIG_PATH}"
 LD_LIBRARY_PATH := "${ICU_LIBDIR}"
 test:
-	echo "ICU version detected: ${ICU_VERSION} ${ICU_LIBDIR}" \
+	       echo "ICU version detected:       ${ICU_VERSION}" \
+	    && echo "ICU libdir:                 ${ICU_LIBDIR}" \
 		&& echo "ICU major version detected: ${ICU_MAJOR_VERSION}" \
+		&& echo "PKG_CONFIG_PATH:            ${PKG_CONFIG_PATH}" \
 		&& PKG_CONFIG_PATH=${PKG_CONFIG_PATH} \
 				LD_LIBRARY_PATH=${LD_LIBRARY_PATH} \
 				cargo test \


### PR DESCRIPTION
Modifies `build.rs` to use the include directory as output by
`pkg-config --cppflags` instead of just the install prefix.

It seems as if this doesn't matter but there are distributions
that take creative liberties with the directory layout and that
confused the old code.

The new code uses the list of include directories, and verifies that
the needed header files are in fact available on the file system
during `build.rs` execution.

See #189