### PR TITLE
Changes in preparation for implementing Intl.DateTimeFormat.

### DIFF
--- a/ecma402_traits/src/datetimeformat.rs
+++ b/ecma402_traits/src/datetimeformat.rs
@@ -273,9 +273,7 @@ pub trait DateTimeFormat {
     /// The `date` holds the number of seconds (with fractional part) since the beginning of the
     /// Unix epoch.  The date is a very generic type because there is no official date-time type
     /// in Rust.
-    fn format<I, D, W>(&self, date: D, writer: &mut W) -> fmt::Result
+    fn format<W>(&self, date: f64, writer: &mut W) -> fmt::Result
     where
-        I: fmt::Display,
-        D: AsRef<f64>,
         W: fmt::Write;
 }

--- a/rust_icu_common/src/lib.rs
+++ b/rust_icu_common/src/lib.rs
@@ -604,3 +604,4 @@ pub fn parse_ok(e: sys::UParseError) -> Result<(), crate::Error> {
     }
     Ok(())
 }
+

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -18,6 +18,7 @@ ecma402_traits = { path = "../ecma402_traits", version = "0.2.0" }
 log = "0.4.6"
 paste = "1.0"
 rust_icu_common = { path = "../rust_icu_common", version = "0.4.1", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "0.4.1", default-features = false }
 rust_icu_sys = { path = "../rust_icu_sys", version = "0.4.1", default-features = false }
 rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.4.1", default-features = false }
 rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.4.1", default-features = false }

--- a/rust_icu_ecma402/src/datetimeformat.rs
+++ b/rust_icu_ecma402/src/datetimeformat.rs
@@ -33,6 +33,7 @@ pub(crate) mod internal {
     use rust_icu_ustring as ustring;
     use std::convert::TryFrom;
 
+    // TODO: implement this conversion completely.
     pub fn opt_to_pattern(_opts: DateTimeFormatOptions) -> Result<ustring::UChar, common::Error> {
         ustring::UChar::try_from("YYYY")
     }

--- a/rust_icu_ecma402/src/datetimeformat.rs
+++ b/rust_icu_ecma402/src/datetimeformat.rs
@@ -1,0 +1,126 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implements the traits found in [ecma402_traits::datetimeformat].
+
+use ecma402_traits;
+use rust_icu_common as common;
+use rust_icu_udat as udat;
+use rust_icu_uloc as uloc;
+use rust_icu_ustring as ustring;
+use std::{convert::TryFrom, fmt};
+
+#[derive(Debug)]
+pub struct DateTimeFormat {
+    // The internal representation of date-time formatting.
+    rep: udat::UDateFormat,
+}
+
+pub(crate) mod internal {
+    use ecma402_traits::datetimeformat::DateTimeFormatOptions;
+    use rust_icu_common as common;
+    use rust_icu_ustring as ustring;
+    use std::convert::TryFrom;
+
+    pub fn opt_to_pattern(_opts: DateTimeFormatOptions) -> Result<ustring::UChar, common::Error> {
+        ustring::UChar::try_from("YYYY")
+    }
+}
+
+impl ecma402_traits::datetimeformat::DateTimeFormat for DateTimeFormat {
+    type Error = common::Error;
+
+    /// Creates a new [DateTimeFormat].
+    ///
+    /// Creation may fail, for example, if the locale-specific data is not loaded,
+    /// or if the supplied options are inconsistent.
+    fn try_new<L>(
+        l: L,
+        opts: ecma402_traits::datetimeformat::DateTimeFormatOptions,
+    ) -> Result<Self, Self::Error>
+    where
+        L: ecma402_traits::Locale,
+        Self: Sized,
+    {
+        let locale: &str = &format!("{}", l);
+        let locale = uloc::ULoc::try_from(locale)?;
+        let pattern = internal::opt_to_pattern(opts)?;
+        // tz_id needs to be  empty per ECMA402 spec.  If you need an alternate
+        // timezone, use a unicode "-tz-" extension on the locale.
+        let tz_id = ustring::UChar::try_from("")?;
+        let rep = udat::UDateFormat::new_with_pattern(&locale, &tz_id, &pattern)?;
+        Ok(DateTimeFormat { rep })
+    }
+
+    /// Formats `date` into the supplied `writer`.
+    ///
+    /// The function implements [`Intl.DateTimeFormat`][link1] from [ECMA 402][ecma].  The `date`
+    /// is expressed in possibly fractional seconds since the Unix Epoch.  The formatting time zone
+    /// and calendar are taken from the locale that was passed into [DateTimeFormat::try_new].
+    ///
+    ///    [link1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat
+    ///    [ecma]: https://www.ecma-international.org/publications/standards/Ecma-402.htm
+    fn format<W>(&self, date: f64, writer: &mut W) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        let result = self.rep.format(date).map_err(|e| e.into())?;
+        write!(writer, "{}", result)
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use super::*;
+    use ecma402_traits::{datetimeformat::DateTimeFormat, datetimeformat::DateTimeFormatOptions};
+    use rust_icu_sys as usys;
+    use rust_icu_uloc as uloc;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn date_time_format_examples() -> Result<(), common::Error> {
+        #[derive(Debug, Clone)]
+        struct TestCase {
+            locale: &'static str,
+            opts: DateTimeFormatOptions,
+            dates: Vec<usys::UDate>,
+            expected: Vec<&'static str>,
+        };
+        let tests = vec![TestCase {
+            locale: "sr_RS-u-tz-uslax",
+            opts: Default::default(),
+            dates: vec![10000_f64],
+            // TBD
+            expected: vec!["1970"],
+        }];
+        for test in tests {
+            let locale =
+                crate::Locale::FromULoc(uloc::ULoc::try_from(test.locale).expect("locale exists"));
+            let formatter = super::DateTimeFormat::try_new(locale, test.clone().opts)?;
+            let actual = test
+                .dates
+                .iter()
+                .map(|d| {
+                    let mut result = String::new();
+                    formatter
+                        .format(*d, &mut result)
+                        .expect(&format!("can format: {}", d));
+                    result
+                })
+                .collect::<Vec<String>>();
+            assert_eq!(test.expected, actual, "for test case: {:?}", &test);
+        }
+        Ok(())
+    }
+}

--- a/rust_icu_ecma402/src/lib.rs
+++ b/rust_icu_ecma402/src/lib.rs
@@ -29,6 +29,11 @@ pub mod pluralrules;
 /// [link]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
 pub mod numberformat;
 
+/// Implements ECMA-402 [`Intl.DateTimeFormat`][link].
+///
+/// [link]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat
+pub mod datetimeformat;
+
 pub enum Locale {
     FromULoc(ULoc),
 }

--- a/rust_icu_udat/src/lib.rs
+++ b/rust_icu_udat/src/lib.rs
@@ -28,6 +28,7 @@ use {
 };
 
 /// Implements `UDateFormat`
+#[derive(Debug)]
 pub struct UDateFormat {
     // Internal C representation of UDateFormat.  It is owned by this type and
     // must be dropped by calling `udat_close`.
@@ -124,6 +125,13 @@ impl UDateFormat {
         let mut status = common::Error::OK_CODE;
         let asciiz = loc.as_c_str();
 
+        // If the timezone is empty, short-circuit it to default.
+        let (tz_id_ptr, tz_id_len): (*const rust_icu_sys::UChar, i32) = if tz_id.len() == 0 {
+            (std::ptr::null(), 0i32)
+        } else {
+            (tz_id.as_c_ptr(), tz_id.len() as i32)
+        };
+
         // Requires that all pointers be valid. Should be guaranteed by all
         // objects passed into this function.
         let date_format = unsafe {
@@ -132,8 +140,8 @@ impl UDateFormat {
                 time_style,
                 date_style,
                 asciiz.as_ptr(),
-                tz_id.as_c_ptr(),
-                tz_id.len() as i32,
+                tz_id_ptr,
+                tz_id_len,
                 pattern.as_c_ptr(),
                 pattern.len() as i32,
                 &mut status,
@@ -251,6 +259,72 @@ impl UDateFormat {
 mod tests {
     use super::*;
 
+    /// Restores the timezone once its scope ends.
+    struct RestoreTimezone {
+        timezone_to_restore: String,
+    }
+
+    impl Drop for RestoreTimezone {
+        fn drop(&mut self) {
+            RestoreTimezone::set_default_time_zone(&self.timezone_to_restore).unwrap();
+        }
+    }
+
+    impl RestoreTimezone {
+        /// Set the timezone to the requested one, and restores to whatever the timezone
+        /// was before the set once the struct goes out of scope.
+        fn new(set_timezone: &str) -> Self {
+            let timezone_to_restore =
+                RestoreTimezone::get_default_time_zone().expect("could get old time zone");
+            RestoreTimezone::set_default_time_zone(set_timezone).expect("set timezone");
+            RestoreTimezone {
+                timezone_to_restore,
+            }
+        }
+
+        // The two methods below are lifted from `rust_icu_ucal` to not introduce
+        // a circular dependency.
+
+        fn set_default_time_zone(zone_id: &str) -> Result<(), common::Error> {
+            let mut status = common::Error::OK_CODE;
+            let mut zone_id_uchar = ustring::UChar::try_from(zone_id)?;
+            zone_id_uchar.make_z();
+            // Requires zone_id_uchar to be a valid pointer until the function returns.
+            unsafe {
+                assert!(common::Error::is_ok(status));
+                versioned_function!(ucal_setDefaultTimeZone)(zone_id_uchar.as_c_ptr(), &mut status);
+            };
+            common::Error::ok_or_warning(status)
+        }
+
+        fn get_default_time_zone() -> Result<String, common::Error> {
+            let mut status = common::Error::OK_CODE;
+
+            // Preflight the time zone first.
+            let time_zone_length = unsafe {
+                assert!(common::Error::is_ok(status));
+                versioned_function!(ucal_getDefaultTimeZone)(std::ptr::null_mut(), 0, &mut status)
+            } as usize;
+            common::Error::ok_preflight(status)?;
+
+            // Should this capacity include the terminating \u{0}?
+            let mut status = common::Error::OK_CODE;
+            let mut uchar = ustring::UChar::new_with_capacity(time_zone_length);
+
+            // Requires that uchar is a valid buffer.  Should be guaranteed by the constructor above.
+            unsafe {
+                assert!(common::Error::is_ok(status));
+                versioned_function!(ucal_getDefaultTimeZone)(
+                    uchar.as_mut_c_ptr(),
+                    time_zone_length as i32,
+                    &mut status,
+                )
+            };
+            common::Error::ok_or_warning(status)?;
+            String::try_from(&uchar)
+        }
+    }
+
     #[test]
     fn test_format_default_calendar() -> Result<(), common::Error> {
         #[derive(Debug)]
@@ -288,6 +362,15 @@ mod tests {
                 date: 100000.0,
                 expected:
                     "среда, 31. децембар 1969. 16:01:40 Северноамеричко пацифичко стандардно време",
+                calendar: None,
+            },
+            Test {
+                name: "Serbian default, with empty timezone defaults to system.",
+                locale: "sr-RS",
+                timezone: "",
+                date: 100000.0,
+                expected:
+                    "четвртак, 01. јануар 1970. 00:01:40 Координисано универзално време",
                 calendar: None,
             },
             Test {
@@ -349,11 +432,12 @@ mod tests {
                 calendar: None,
             },
         ];
+        let _restore_timezone = RestoreTimezone::new("UTC");
         for t in tests {
             let loc = uloc::ULoc::try_from(t.locale)?;
             let tz_id = ustring::UChar::try_from(t.timezone)?;
 
-            let mut fmt = UDateFormat::new_with_styles(
+            let mut fmt = super::UDateFormat::new_with_styles(
                 sys::UDateFormatStyle::UDAT_FULL,
                 sys::UDateFormatStyle::UDAT_FULL,
                 &loc,
@@ -403,7 +487,7 @@ mod tests {
         let tz_id = ustring::UChar::try_from("America/New_York")?;
         for t in tests {
             let pattern = ustring::UChar::try_from(t.pattern)?;
-            let fmt = UDateFormat::new_with_pattern(&loc, &tz_id, &pattern)?;
+            let fmt = super::UDateFormat::new_with_pattern(&loc, &tz_id, &pattern)?;
             let actual = fmt.format(t.date)?;
             assert_eq!(
                 actual, t.expected,
@@ -441,7 +525,7 @@ mod tests {
 
         for test in tests {
             let pattern = ustring::UChar::try_from(test.pattern)?;
-            let format = UDateFormat::new_with_pattern(&loc, &tz_id, &pattern)?;
+            let format = super::UDateFormat::new_with_pattern(&loc, &tz_id, &pattern)?;
             let actual = format.parse(test.input)?;
             assert_eq!(
                 actual, test.expected,

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -21,6 +21,7 @@ use {
     rust_icu_uenum::Enumeration,
     std::{
         cmp::Ordering,
+        collections::HashMap,
         convert::{From, TryFrom, TryInto},
         ffi, fmt,
         os::raw,
@@ -30,6 +31,109 @@ use {
 /// Maximum length of locale supported by uloc.h.
 /// See `ULOC_FULLNAME_CAPACITY`.
 const LOCALE_CAPACITY: usize = 158;
+
+/// [ULocMut] is a mutable companion to [ULoc].
+///
+/// It has methods that allow one to create a different [ULoc] by adding and
+/// removing keywords to the locale identifier.  You can only creates a `ULocMut`
+/// by converting from an existing `ULoc` by calling `ULocMut::from`.  And once
+/// you are done changing it, you can only convert it back with `ULoc::from`.
+///
+/// [ULocMut] is not meant to have comprehensive coverage of mutation options.
+/// They may be added as necessary.
+#[derive(Debug, Clone)]
+pub struct ULocMut {
+    base: ULoc,
+    unicode_keyvalues: HashMap<String, String>,
+    other_keyvalues: HashMap<String, String>,
+}
+
+impl From<ULoc> for ULocMut {
+    /// Turns [ULoc] into [ULocMut], which can be mutated.
+    fn from(l: ULoc) -> Self {
+        let all_keywords = l.keywords();
+        let mut unicode_keyvalues: HashMap<String, String> = HashMap::new();
+        let mut other_keyvalues: HashMap<String, String> = HashMap::new();
+        for kw in all_keywords {
+            // Despite the many unwraps below, none should be triggered, since we know
+            // that the keywords come from the list of keywords that already exist.
+            let ukw = to_unicode_locale_key(&kw);
+            match ukw {
+                None => {
+                    let v = l.keyword_value(&kw).unwrap().unwrap();
+                    other_keyvalues.insert(kw, v);
+                }
+                Some(u) => {
+                    let v = l.unicode_keyword_value(&u).unwrap().unwrap();
+                    unicode_keyvalues.insert(u, v);
+                }
+            }
+        }
+        let base = l.base_name();
+        ULocMut {
+            base,
+            unicode_keyvalues,
+            other_keyvalues,
+        }
+    }
+}
+
+impl From<ULocMut> for ULoc {
+    // Creates an [ULoc] from [ULocMut].
+    fn from(lm: ULocMut) -> Self {
+        // Assemble the unicode extension.
+        let mut unicode_extensions_vec = lm
+            .unicode_keyvalues
+            .iter()
+            .map(|(k, v)| format!("{}-{}", k, v))
+            .collect::<Vec<String>>();
+        unicode_extensions_vec.sort();
+        let unicode_extensions: String = unicode_extensions_vec
+            .join("-");
+        let unicode_extension: String = if unicode_extensions.len() > 0 {
+            vec!["u-".to_string(), unicode_extensions]
+                .into_iter()
+                .collect()
+        } else {
+            "".to_string()
+        };
+        // Assemble all other extensions.
+        let mut all_extensions: Vec<String> = lm
+            .other_keyvalues
+            .iter()
+            .map(|(k, v)| format!("{}-{}", k, v))
+            .collect();
+        if unicode_extension.len() > 0 {
+            all_extensions.push(unicode_extension);
+        }
+        all_extensions.sort();
+        let extension_string = all_extensions.join("-");
+        let everything = vec![lm.base.repr, extension_string].join("-");
+        ULoc::for_language_tag(&everything).unwrap()
+    }
+}
+
+impl ULocMut {
+    /// Sets the specified unicode extension keyvalue.  Only valid keys can be set,
+    /// inserting an invalid extension key does not change [ULocMut].
+    pub fn set_unicode_keyvalue(&mut self, key: &str, value: &str) -> Option<String> {
+        if let None = to_unicode_locale_key(key) {
+            return None;
+        }
+        self.unicode_keyvalues
+            .insert(key.to_string(), value.to_string())
+    }
+
+    /// Removes the specified unicode extension keyvalue.  Only valid keys can
+    /// be removed, attempting to remove an invalid extension key does not
+    /// change [ULocMut].
+    pub fn remove_unicode_keyvalue(&mut self, key: &str) -> Option<String> {
+        if let None = to_unicode_locale_key(key) {
+            return None;
+        }
+        self.unicode_keyvalues.remove(key)
+    }
+}
 
 /// A representation of a Unicode locale.
 ///
@@ -250,6 +354,14 @@ impl ULoc {
         } else {
             Some(value)
         }
+    }
+
+    /// Implements `uloc_getBaseName` from ICU4C.
+    pub fn base_name(self) -> Self {
+        let result = self
+            .call_buffered_string_method(versioned_function!(uloc_getBaseName))
+            .expect("should be able to produce a shorter locale");
+        ULoc::try_from(&result[..]).expect("should be able to convert to locale")
     }
 }
 
@@ -563,6 +675,19 @@ mod tests {
     }
 
     #[test]
+    fn test_keywords_nounicode() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("az-Cyrl-AZ-u-ca-hebrew-t-it-x-whatever")?;
+        let keywords: Vec<String> = loc.keywords().collect();
+        assert_eq!(
+            keywords,
+            vec!["calendar".to_string(), "t".to_string(), "x".to_string(),]
+        );
+        assert_eq!(loc.keyword_value("t")?.unwrap(), "it");
+        assert_eq!(loc.keyword_value("x")?.unwrap(), "whatever");
+        Ok(())
+    }
+
+    #[test]
     fn test_keywords_empty() -> Result<(), Error> {
         let loc = ULoc::for_language_tag("az-Cyrl-AZ")?;
         let keywords: Vec<String> = loc.keywords().collect();
@@ -761,6 +886,58 @@ mod tests {
         assert_eq!(str_to_cstring("abc"), ffi::CString::new("abc")?);
         assert_eq!(str_to_cstring("abc\0def"), ffi::CString::new("abc")?);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_base_name() -> Result<(), Error> {
+        assert_eq!(
+            ULoc::try_from("en-u-tz-uslax-x-foo")?.base_name(),
+            ULoc::try_from("en")?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_uloc_mut() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("en-t-it-u-tz-uslax-x-foo")?;
+        let loc_mut = ULocMut::from(loc);
+        let loc = ULoc::from(loc_mut);
+        assert_eq!(ULoc::for_language_tag("en-t-it-u-tz-uslax-x-foo")?, loc);
+        Ok(())
+    }
+
+    #[test]
+    fn test_uloc_mut_changes() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("en-t-it-u-tz-uslax-x-foo")?;
+        let mut loc_mut = ULocMut::from(loc);
+        loc_mut.remove_unicode_keyvalue("tz");
+        let loc = ULoc::from(loc_mut);
+        assert_eq!(ULoc::for_language_tag("en-t-it-x-foo")?, loc);
+
+        let loc = ULoc::for_language_tag("en-u-tz-uslax")?;
+        let mut loc_mut = ULocMut::from(loc);
+        loc_mut.remove_unicode_keyvalue("tz");
+        let loc = ULoc::from(loc_mut);
+        assert_eq!(ULoc::for_language_tag("en")?, loc);
+        Ok(())
+    }
+
+    #[test]
+    fn test_uloc_mut_overrides() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("en-t-it-u-tz-uslax-x-foo")?;
+        let mut loc_mut = ULocMut::from(loc);
+        loc_mut.set_unicode_keyvalue("tz", "usnyc");
+        let loc = ULoc::from(loc_mut);
+        assert_eq!(ULoc::for_language_tag("en-t-it-u-tz-usnyc-x-foo")?, loc);
+
+        let loc = ULoc::for_language_tag("en-t-it-u-tz-uslax-x-foo")?;
+        let mut loc_mut = ULocMut::from(loc);
+        loc_mut.set_unicode_keyvalue("tz", "usnyc");
+        loc_mut.set_unicode_keyvalue("nu", "arabic");
+        let loc = ULoc::from(loc_mut);
+        assert_eq!(ULoc::for_language_tag("en-t-it-u-nu-arabic-tz-usnyc-x-foo")?, loc);
+        assert_eq!(ULoc::for_language_tag("en-t-it-u-tz-usnyc-nu-arabic-x-foo")?, loc);
         Ok(())
     }
 }

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -940,4 +940,14 @@ mod tests {
         assert_eq!(ULoc::for_language_tag("en-t-it-u-tz-usnyc-nu-arabic-x-foo")?, loc);
         Ok(())
     }
+
+    #[test]
+    fn test_uloc_mut_add_unicode_extension() -> Result<(), Error> {
+        let loc = ULoc::for_language_tag("en-t-it-x-foo")?;
+        let mut loc_mut = ULocMut::from(loc);
+        loc_mut.set_unicode_keyvalue("tz", "usnyc");
+        let loc = ULoc::from(loc_mut);
+        assert_eq!(ULoc::for_language_tag("en-t-it-u-tz-usnyc-x-foo")?, loc);
+        Ok(())
+    }
 }


### PR DESCRIPTION
I realized that, in order to initialize the date-time formatter
propertly, I will need to admit changes to a once-defined locale.

So, adding the code that does that.

See: #135