### PR TITLE
Add --force to buildenvs

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -10,7 +10,8 @@ readonly __all_dirs="$(ls -d rust_icu_*)"
 
 env
 
-cargo install bindgen rustfmt
+# --force is needed to override the currently installed versions.
+cargo install --force bindgen rustfmt
 
 function run_cargo_test() {
   env LD_LIBRARY_PATH="/usr/local/lib" cargo test ${CARGO_TEST_ARGS}


### PR DESCRIPTION
It turns out that it is no longer allowed to install without --force if binaries are already there.
Apparently, `--force` will allow it.

Tested locally:

```
git tag -a 1.4.2-rc1
(cd build && make)
env USED_BUILDENV_VERSION=1.4.2-rc1 RUST_ICU_MAJOR_VERSOIN_NUMBER=69 \
       make docker-test
```

Issue #198