### PR TITLE
Uprev to 1.0.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,8 @@ publish:
 # A helper to up-rev the cargo crate versions.
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
-UPREV_OLD_VERSION ?= 0.5.0
-UPREV_NEW_VERSION ?= 0.5.1
+UPREV_OLD_VERSION ?= 1.0.0
+UPREV_NEW_VERSION ?= 1.0.1
 define uprevfn
 	( \
 		cd $(1) && \

--- a/ecma402_traits/Cargo.toml
+++ b/ecma402_traits/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "ecma402_traits"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Rust implementation of type traits to support ECMA 402 specification in Rust.

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,20 +18,20 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "0.5.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.5.0", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "0.5.0", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "0.5.0", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "0.5.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.5.0", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.5.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.5.0", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "0.5.0", default-features = false }
-rust_icu_utrans = { path = "../rust_icu_utrans", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "1.0.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "1.0.0", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "1.0.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "1.0.0", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "1.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "1.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "1.0.0", default-features = false }
+rust_icu_utrans = { path = "../rust_icu_utrans", version = "1.0.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "0.5.0"
+version = "1.0.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -7,25 +7,25 @@ license = "Apache-2.0"
 name = "rust_icu_ecma402"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 ECMA 402 standard implementation in Rust.
 """
 [dependencies]
 anyhow = "1.0.25"
-ecma402_traits = { path = "../ecma402_traits", version = "0.5.0" }
+ecma402_traits = { path = "../ecma402_traits", version = "1.0.0" }
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "0.5.0", default-features = false }
-rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "0.5.0", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "0.5.0", default-features = false }
-rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "1.0.0", default-features = false }
+rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "1.0.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "1.0.0", default-features = false }
+rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "1.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.5.0", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "0.5.0"
+version = "1.0.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "rust_icu_ubrk"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -20,12 +20,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.5.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.5.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "1.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uformattable"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,9 +18,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,9 +18,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -19,10 +19,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "0.5.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "1.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,11 +18,11 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "0.5.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "1.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unumberformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -19,12 +19,12 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "0.5.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "0.5.0", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "1.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "0.5.0"
+version = "1.0.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "rust_icu_utrans"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "0.5.0"
+version = "1.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,10 +19,10 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "0.5.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "0.5.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "0.5.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "0.5.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"


### PR DESCRIPTION
We got to a point where ECMA 402 functionality has been provided.
From here on, we can add features as they become needed, or as
contributions (maybe) roll in.