### PR TITLE
Deflake the date time format test

### DIFF
--- a/rust_icu_ecma402/src/datetimeformat.rs
+++ b/rust_icu_ecma402/src/datetimeformat.rs
@@ -275,6 +275,9 @@ mod testing {
                 locale: "sr-RS",
                 opts: DateTimeFormatOptions{
                     year:  Some(options::DisplaySize::Numeric),
+                    // If time_zone is unset, this becomes a conversion into the
+                    // "local" time zone, which may make this test brittle.
+                    time_zone: Some("UTC".into()),
                     ..Default::default()
                 },
 


### PR DESCRIPTION
The date time format test didn't have a time zone chosen.
This meant that the date time formatting was done based
on the local time zone, which can vary across machines.

I didn't catch this originally because I worked on a
machine that was in UTC, just the same as the machines
which were running the tests.