### PR TITLE
Remove compile warnings stemming from Cargo.toml.

### DIFF
--- a/ecma402_traits/Cargo.toml
+++ b/ecma402_traits/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 authors = ["Google Inc."]
-default-features = false
 edition = "2018"
 keywords = ["ecma", "ecma402", "icu", "i18n", "l10n"]
 license = "Apache-2.0"

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 authors = ["Google Inc."]
-default-features = false
 edition = "2018"
 license = "Apache-2.0"
 name = "rust_icu"

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -12,7 +12,6 @@ Native bindings to the ICU4C library from Unicode.
 
 Commonly used types.
 """
-default-features = false
 
 keywords = ["icu", "unicode", "i18n", "l10n"]
 

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 authors = ["Google Inc."]
-default-features = false
 edition = "2018"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 license = "Apache-2.0"

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 authors = ["Google Inc."]
-default-features = false
 edition = "2018"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 license = "Apache-2.0"

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -6,7 +6,6 @@ name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
 version = "1.0.0"
-default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-anyhow = "1.0"
 authors = ["Google Inc."]
 build = "build.rs"
 edition = "2018"

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -6,7 +6,6 @@ name = "rust_icu_uformattable"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
 version = "1.0.0"
-default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -6,7 +6,6 @@ name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
 version = "1.0.0"
-default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -7,7 +7,6 @@ build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
 version = "1.0.0"
-default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -6,7 +6,6 @@ name = "rust_icu_unum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
 version = "1.0.0"
-default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -6,7 +6,6 @@ name = "rust_icu_unumberformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
 version = "1.0.0"
-default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -6,7 +6,6 @@ name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
 version = "1.0.0"
-default-features = false
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 authors = ["Google Inc."]
-default-features = false
 edition = "2018"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 license = "Apache-2.0"


### PR DESCRIPTION
This change removes the extraneous warnings from the Cargo.toml files
which accummulated but wre never removed. I realized that they are
printed on every cargo invocation, which makes for a lot of unneded
output.

So, removed.