### PR TITLE
Adopts the C++ comments from the ICU library

### DIFF
--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -279,10 +279,6 @@ mod inner {
             })
             // Bindings are pretty much unreadable without rustfmt.
             .rustfmt_bindings(true)
-            // Some comments get recognized as rust doctests, which will fail compilation.
-            // Turning the comments off will remove that error.  We do get left without
-            // documentation, but one should probably use online docs anyways.
-            .generate_comments(false)
             // These attributes are useful to have around for generated types.
             .derive_default(true)
             .derive_hash(true)

--- a/rust_icu_sys/src/lib.rs
+++ b/rust_icu_sys/src/lib.rs
@@ -17,7 +17,8 @@
     non_snake_case,
     non_camel_case_types,
     non_upper_case_globals,
-    unused_imports
+    unused_imports,
+    rustdoc::bare_urls,
 )]
 
 #[cfg(all(feature = "icu_version_in_env", feature = "icu_config"))]


### PR DESCRIPTION
Earlier versions of cargo insisted on running comments generated
from C++ code as rust tests when the comment lines were indented.

This is of course not correct behavior for generated code. Since at
the time there was no way to turn the behavior off, we had to turn
off documentation generation.

Now that the behavior seems to be implemented, we can start
generating docs again.