### PR TITLE
Suppress nullptr dereference warning in rust_icu_sys/src/lib.rs.

### DIFF
--- a/rust_icu_sys/src/lib.rs
+++ b/rust_icu_sys/src/lib.rs
@@ -12,12 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #![doc(test(ignore))]
+
+// Notes:
+// * deref_nullptr: since rustc 1.53, bindgen causes UB warnings -- see
+// https://github.com/rust-lang/rust-bindgen/issues/1651 remove this once bindgen has fixed the
+// issue (currently at version 1.59.1)
 #![allow(
     dead_code,
     non_snake_case,
     non_camel_case_types,
     non_upper_case_globals,
-    unused_imports
+    unused_imports,
+    deref_nullptr,
 )]
 
 #[cfg(all(feature = "icu_version_in_env", feature = "icu_config"))]


### PR DESCRIPTION
The warning comes about because `bindgen` chooses to use an UB idiom to
generate tests. There is nothing that `rust_icu` can reasonably do about
it.  But since `bindgen` folks are interested in resolving the issue, we
can hope that future `bindgen` versions will resolve the issue.

In the meantime, let's not pollute the (already verbose) build output with
these warnings.

See: https://github.com/rust-lang/rust-bindgen/issues/1651 for details.