### PR TITLE
Use make dependency tracking for some crate publications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ endef
 
 # Everyone's dependency.
 publish-rust_icu_sys:
-	$(call publishfn,rust_icu_sys)
+	#$(call publishfn,rust_icu_sys)
 .PHONY: publish-rust_icu_sys
 
 publish-rust_icu: publish-rust_icu_sys
@@ -197,7 +197,7 @@ uprev:
 	$(call uprevfn,rust_icu_ecma402)
 	$(call uprevfn,ecma402_traits)
 	$(call uprevfn,rust_icu_unorm2)
-	$(call uprevfn,uchar)
+	$(call uprevfn,rust_icu_uchar)
 .PHONY: uprev
 
 cov:

--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,15 @@ define publishfn
 	( cd $(1) && cargo publish && sleep 30)
 endef
 
-# This is not the best method, since it will error out if a crate has already
-# been published.
-publish:
+######################################################################
+## Targets for publishing crates to crates.io
+
+# Everyone's dependency.
+publish-rust_icu_sys:
 	$(call publishfn,rust_icu_sys)
+.PHONY: publish-rust_icu_sys
+
+publish-rust_icu: publish-rust_icu_sys
 	$(call publishfn,rust_icu_common)
 	$(call publishfn,rust_icu_uenum)
 	$(call publishfn,rust_icu_ustring)
@@ -139,11 +144,21 @@ publish:
 	$(call publishfn,rust_icu_unum)
 	$(call publishfn,rust_icu_ubrk)
 	$(call publishfn,rust_icu_utrans)
-	$(call publishfn,rust_icu)
 	$(call publishfn,rust_icu_unumberformatter)
-	$(call publishfn,rust_icu_ecma402)
 	$(call publishfn,rust_icu_unorm2)
 	$(call publishfn,rust_icu_uchar)
+.PHONY: publish-rust_icu
+
+publish-ecma402_traits:
+	$(call publishfn,ecma402_traits)
+.PHONY: publish-ecma402_traits
+
+publish-rust_icu_ecma402: publish-rust_icu publish-ecma402_traits
+	$(call publishfn,rust_icu_ecma402)
+.PHONY: publish-rust_icu_ecma402
+
+publish: publish-rust_icu publish-rust_icu_ecma402
+	$(call publishfn,rust_icu)
 .PHONY: publish
 
 # A helper to up-rev the cargo crate versions.

--- a/rust_icu_uchar/Cargo.toml
+++ b/rust_icu_uchar/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uchar"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.1"
+version = "1.0.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]


### PR DESCRIPTION
Broke the target `publish` into a few smaller targets and added the correct
dependencies between those targets.

This removes a certain class of errors from publishing crates in the wrong
order.  The approach could be continued to its logical conclusion, but for
the time being I opted not to do that.