### PR TITLE
Adjust the time zone data regex

### DIFF
--- a/rust_icu_ucal/src/lib.rs
+++ b/rust_icu_ucal/src/lib.rs
@@ -389,9 +389,9 @@ mod tests {
 
     #[test]
     fn test_get_tz_data_version() {
-        let re = Regex::new(r"^[0-9][0-9][0-9][0-9][a-z]$").expect("valid regex");
+        let re = Regex::new(r"^[0-9][0-9][0-9][0-9][a-z][a-z0-9]*$").expect("valid regex");
         let tz_version = super::get_tz_data_version().expect("get_tz_data_version works");
-        assert!(re.is_match(&tz_version));
+        assert!(re.is_match(&tz_version), "version was: {:?}", &tz_version);
     }
 
     #[test]


### PR DESCRIPTION
Starting from ICU 70, the time zone data version can have more than a
single letter after the release number. We used to have versions like
`2020a`, `2020b` etc.  With ICU 70, we get `2021a1`.

We're adopting the same regex as in:
https://fuchsia-review.googlesource.com/c/fuchsia/+/597898
for quick checks of the version string.

Fixes: #221