### PR TITLE
Icu 70

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         icu_version: [63]
         feature_set:
-          - "renaming,icu_version_in_env"
+          - "renaming,icu_version_in_env,icu_version_69_max"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}
@@ -32,8 +32,8 @@ jobs:
       matrix:
         icu_version: [67]
         feature_set:
-          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus"
-          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_config,use-bindgen"
+          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus,icu_version_69_max"
+          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_config,use-bindgen,icu_version_69_max"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}
@@ -44,8 +44,8 @@ jobs:
       matrix:
         icu_version: [68, 69]
         feature_set:
-          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus"
-          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_config,use-bindgen"
+          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_version_69_max"
+          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_config,use-bindgen,icu_version_69_max"
     steps:
       - uses: actions/checkout@v2
       - name: Test ICU version ${{ matrix.icu_version }}

--- a/build/Makefile
+++ b/build/Makefile
@@ -33,8 +33,15 @@ tag-%: build-%
 push-%: tag-%
 	docker push ${DOCKER_REPO}/rust_icu_$*:${VERSION}
 
+latest: \
+	push-maint-70 \
+	push-testenv-70
+.PHONY: latest
+
 all: \
 	push-buildenv \
+	push-maint-70 \
+	push-testenv-70 \
 	push-maint-69 \
 	push-testenv-69 \
 	push-maint-68 \
@@ -46,3 +53,4 @@ all: \
 	push-testenv \
 	push-hermetic
 	echo "buildenv-version: ${VERSION}"
+.PHONY: all

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -157,6 +157,23 @@ icu_version_68_plus = [
   "rust_icu_utext/icu_version_68_plus",
   "rust_icu_utrans/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_ubrk/icu_version_69_max",
+  "rust_icu_ucal/icu_version_69_max",
+  "rust_icu_ucol/icu_version_69_max",
+  "rust_icu_udat/icu_version_69_max",
+  "rust_icu_udata/icu_version_69_max",
+  "rust_icu_uenum/icu_version_69_max",
+  "rust_icu_ulistformatter/icu_version_69_max",
+  "rust_icu_uloc/icu_version_69_max",
+  "rust_icu_umsg/icu_version_69_max",
+  "rust_icu_unorm2/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+  "rust_icu_utext/icu_version_69_max",
+  "rust_icu_utrans/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -37,6 +37,9 @@ icu_version_67_plus = [
 icu_version_68_plus = [
   "rust_icu_sys/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_sys/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -103,6 +103,16 @@ icu_version_68_plus = [
   "rust_icu_upluralrules/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_ulistformatter/icu_version_69_max",
+  "rust_icu_uloc/icu_version_69_max",
+  "rust_icu_unum/icu_version_69_max",
+  "rust_icu_unumberformatter/icu_version_69_max",
+  "rust_icu_upluralrules/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -77,3 +77,10 @@ icu_version_68_plus = [
   "rust_icu_umsg/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_uloc/icu_version_69_max",
+  "rust_icu_umsg/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -41,6 +41,7 @@ icu_version_in_env = []
 icu_version_64_plus = []
 icu_version_67_plus = []
 icu_version_68_plus = []
+icu_version_69_max = []
 
 
 [badges]

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -416,16 +416,22 @@ macro_rules! versioned_function {{
         if env::var_os("CARGO_FEATURE_ICU_VERSION_IN_ENV").is_some() {
             println!("cargo:rustc-cfg=feature=\"icu_version_in_env\"");
         }
-        let version_major = ICUConfig::version_major_int()?;
-        println!("icu-version-major: {}", version_major);
-        if version_major >= 64 {
+        let icu_major_version = ICUConfig::version_major_int()?;
+        println!("icu-version-major: {}", icu_major_version);
+        if icu_major_version >= 64 {
             println!("cargo:rustc-cfg=feature=\"icu_version_64_plus\"");
         }
-        if version_major >= 67 {
+        if icu_major_version >= 67 {
             println!("cargo:rustc-cfg=feature=\"icu_version_67_plus\"");
         }
-        if version_major >= 68 {
+        if icu_major_version >= 68 {
             println!("cargo:rustc-cfg=feature=\"icu_version_68_plus\"");
+        }
+        // Starting from version 69, the feature flags depending on the version
+        // number work for up to a certain version, so that they can be retired
+        // over time.
+        if icu_major_version <= 69 {
+            println!("cargo:rustc-cfg=feature=\"icu_version_69_max\"");
         }
         Ok(())
     }

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -71,6 +71,12 @@ icu_version_68_plus = [
   "rust_icu_uloc/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_uloc/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "google/rust_icu" }

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -73,6 +73,12 @@ icu_version_68_plus = [
   "rust_icu_uenum/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_uenum/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ucal/src/lib.rs
+++ b/rust_icu_ucal/src/lib.rs
@@ -389,9 +389,9 @@ mod tests {
 
     #[test]
     fn test_get_tz_data_version() {
-        let re = Regex::new(r"^[0-9][0-9][0-9][0-9][a-z]$").expect("valid regex");
+        let re = Regex::new(r"^[0-9][0-9][0-9][0-9][a-z][a-z0-9]*$").expect("valid regex");
         let tz_version = super::get_tz_data_version().expect("get_tz_data_version works");
-        assert!(re.is_match(&tz_version));
+        assert!(re.is_match(&tz_version), "version was: {:?}", &tz_version);
     }
 
     #[test]

--- a/rust_icu_uchar/Cargo.toml
+++ b/rust_icu_uchar/Cargo.toml
@@ -41,4 +41,8 @@ icu_version_68_plus = [
   "rust_icu_common/icu_version_68_plus",
   "rust_icu_sys/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+]
 

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -72,6 +72,12 @@ icu_version_68_plus = [
   "rust_icu_uenum/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_uenum/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -92,6 +92,14 @@ icu_version_68_plus = [
   "rust_icu_uloc/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_ucal/icu_version_69_max",
+  "rust_icu_uenum/icu_version_69_max",
+  "rust_icu_uloc/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_udat/build.rs
+++ b/rust_icu_udat/build.rs
@@ -112,6 +112,12 @@ fn main() -> anyhow::Result<()> {
     if icu_major_version >= 68 {
         println!("cargo:rustc-cfg=feature=\"icu_version_68_plus\"");
     }
+    // Starting from version 69, the feature flags depending on the version
+    // number work for up to a certain version, so that they can be retired
+    // over time.
+    if icu_major_version <= 69 {
+        println!("cargo:rustc-cfg=feature=\"icu_version_69_max\"");
+    }
     println!("done");
     Ok(())
 }

--- a/rust_icu_udat/src/lib.rs
+++ b/rust_icu_udat/src/lib.rs
@@ -427,6 +427,17 @@ mod tests {
                     "среда, 31. децембар 1969. 16:01:40 Северноамеричко пацифичко стандардно време",
                 calendar: None,
             },
+            #[cfg(not(feature = "icu_version_69_max"))]
+            Test {
+                name: "Serbian default, with empty timezone defaults to system.",
+                locale: "sr-RS",
+                timezone: "",
+                date: 100000.0,
+                expected:
+                    "четвртак, 1. јануар 1970. 00:01:40 Координисано универзално време",
+                calendar: None,
+            },
+            #[cfg(feature = "icu_version_69_max")]
             Test {
                 name: "Serbian default, with empty timezone defaults to system.",
                 locale: "sr-RS",

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -41,6 +41,10 @@ icu_version_68_plus = [
   "rust_icu_common/icu_version_68_plus",
   "rust_icu_sys/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -40,6 +40,10 @@ icu_version_68_plus = [
   "rust_icu_common/icu_version_68_plus",
   "rust_icu_sys/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -64,6 +64,11 @@ icu_version_68_plus = [
   "rust_icu_sys/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -64,6 +64,11 @@ icu_version_68_plus = [
   "rust_icu_sys/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -72,6 +72,12 @@ icu_version_68_plus = [
   "rust_icu_uenum/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_uenum/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [build-dependencies]
 anyhow = "1.0"

--- a/rust_icu_uloc/build.rs
+++ b/rust_icu_uloc/build.rs
@@ -112,6 +112,12 @@ fn main() -> anyhow::Result<()> {
     if icu_major_version >= 68 {
         println!("cargo:rustc-cfg=feature=\"icu_version_68_plus\"");
     }
+    // Starting from version 69, the feature flags depending on the version
+    // number work for up to a certain version, so that they can be retired
+    // over time.
+    if icu_major_version <= 69 {
+        println!("cargo:rustc-cfg=feature=\"icu_version_69_max\"");
+    }
     println!("done");
     Ok(())
 }

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -74,6 +74,12 @@ icu_version_68_plus = [
   "rust_icu_uloc/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_uloc/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_unorm2/Cargo.toml
+++ b/rust_icu_unorm2/Cargo.toml
@@ -91,6 +91,14 @@ icu_version_68_plus = [
   "rust_icu_uloc/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_ucal/icu_version_69_max",
+  "rust_icu_uenum/icu_version_69_max",
+  "rust_icu_uloc/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -80,6 +80,13 @@ icu_version_68_plus = [
   "rust_icu_uloc/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_uformattable/icu_version_69_max",
+  "rust_icu_uloc/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -88,6 +88,14 @@ icu_version_68_plus = [
   "rust_icu_unum/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_uformattable/icu_version_69_max",
+  "rust_icu_uloc/icu_version_69_max",
+  "rust_icu_unum/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -72,6 +72,12 @@ icu_version_68_plus = [
   "rust_icu_uenum/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_uenum/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -41,4 +41,9 @@ icu_version_68_plus = [
   "rust_icu_common/icu_version_68_plus",
   "rust_icu_sys/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+]
+
 

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -40,6 +40,10 @@ icu_version_68_plus = [
   "rust_icu_common/icu_version_68_plus",
   "rust_icu_sys/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -72,6 +72,12 @@ icu_version_68_plus = [
   "rust_icu_uenum/icu_version_68_plus",
   "rust_icu_ustring/icu_version_68_plus",
 ]
+icu_version_69_max = [
+  "rust_icu_common/icu_version_69_max",
+  "rust_icu_sys/icu_version_69_max",
+  "rust_icu_uenum/icu_version_69_max",
+  "rust_icu_ustring/icu_version_69_max",
+]
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "google/rust_icu" }


### PR DESCRIPTION
Makes the necessary changes to have rust_icu compile with ICU 70.1
    
The two changes needed were timezone data version regex upgrade and a test touch-up.
    
This has been tested locally. Followup work will provide the builders.
    
Issue: #223
