### PR TITLE
Remove the (unused) features

### DIFF
--- a/rust_icu_uchar/src/lib.rs
+++ b/rust_icu_uchar/src/lib.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![feature(proc_macro_hygiene)]
 
 //! # ICU unicode character properties support
 //!

--- a/rust_icu_unum/src/lib.rs
+++ b/rust_icu_unum/src/lib.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![feature(proc_macro_hygiene)]
 
 //! # ICU number formatting support for rust
 //!

--- a/rust_icu_unumberformatter/src/lib.rs
+++ b/rust_icu_unumberformatter/src/lib.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![feature(proc_macro_hygiene)]
 
 //! # ICU number formatting support for rust (modern)
 //!


### PR DESCRIPTION
These prevented rust_icu from being compilable with the stable rust
toolchain.  It seems that the features are unused at the moment, or
have melded into the more recent stable toolchain versions.

Issue: #225