### PR TITLE
Uprev rust_icu to 2.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        icu_version: [63, 67, 68, 69, 70]
+        icu_version: [63, 68, 69, 70]
     steps:
       - uses: actions/checkout@v2
       - name: 'Test ICU version ${{ matrix.icu_version }}'
@@ -25,18 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 'Test ICU version ${{ matrix.icu_version }}'
-        run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version }} RUST_ICU_MAJOR_VERSION_NUMBER=${{ matrix.icu_version }} DOCKER_TEST_CARGO_TEST_ARGS="--no-default-features --features ${{ matrix.feature_set }}" docker-test'
-  test-67-plus-features:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        icu_version: [67]
-        feature_set:
-          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus,icu_version_69_max"
-          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_config,use-bindgen,icu_version_69_max"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Test ICU version ${{ matrix.icu_version }}
         run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version }} RUST_ICU_MAJOR_VERSION_NUMBER=${{ matrix.icu_version }} DOCKER_TEST_CARGO_TEST_ARGS="--no-default-features --features ${{ matrix.feature_set }}" docker-test'
   test-69-plus-features:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ publish-rust_icu: publish-rust_icu_sys
 	$(call publishfn,rust_icu_unumberformatter)
 	$(call publishfn,rust_icu_unorm2)
 	$(call publishfn,rust_icu_uchar)
+	$(call publishfn,rust_icu_ucnv)
 .PHONY: publish-rust_icu
 
 publish-ecma402_traits:
@@ -165,8 +166,8 @@ publish: publish-rust_icu publish-rust_icu_ecma402
 # A helper to up-rev the cargo crate versions.
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
-UPREV_OLD_VERSION ?= 1.0.3
-UPREV_NEW_VERSION ?= 1.0.4
+UPREV_OLD_VERSION ?= 2.0.0
+UPREV_NEW_VERSION ?= 2.0.1
 define uprevfn
 	( \
 		cd $(1) && \
@@ -199,6 +200,7 @@ uprev:
 	$(call uprevfn,ecma402_traits)
 	$(call uprevfn,rust_icu_unorm2)
 	$(call uprevfn,rust_icu_uchar)
+	$(call uprevfn,rust_icu_ucnv)
 .PHONY: uprev
 
 cov:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Item           | Description
 -------------- | -----------
-ICU 63, 67..69 | [![Test status](https://github.com/google/rust_icu/workflows/Test/badge.svg)](https://github.com/google/rust_icu/workflows/Test/badge.svg)
+ICU 63, 68..70 | [![Test status](https://github.com/google/rust_icu/workflows/Test/badge.svg)](https://github.com/google/rust_icu/workflows/Test/badge.svg)
 Source         | https://github.com/google/rust_icu
 README         | https://github.com/google/rust_icu/blob/main/README.md
 Coverage       | [View report](/coverage/report.md)
@@ -34,8 +34,8 @@ https://github.com/google/rust_icu.
     confirms that ICU support in rust is spotty, so having a functional wrapper
     helps advance the state of the art.
 
-*   Projects such as [Fuchsia OS](https://fuchsia.dev) already depend on ICU,
-    and having rust bindings allow for an easy way to use Unicode algorithms
+*   Projects such as [Fuchsia](https://fuchsia.dev) already depend on ICU,
+    and having rust bindings allows for an easy way to use Unicode algorithms
     without taking on more dependencies.
 
 *   Cooperation on the interface with projects such as the
@@ -108,23 +108,22 @@ The limitations we know of today are as follows:
 
 The compatibility guarantee is as follows:
 
-1. Up to 3 minor releases of `rust_icu` are tested for each major release
-2. Automated tests are executed for last three major ICU library versions in all
+1. Automated tests are executed for last three major ICU library versions in all
    feature combinations of interest.
-3. Automated tests are executed for the ICU library version in use by the docs.rs
+2. Automated tests are executed for the ICU library version in use by the docs.rs
    system (so the documentation could be built).
 
-`rust_icu` version   | ICU 63.x | ICU 64.2 | ICU 65.1 | ICU 66.0.1 | ICU 67.1 | ICU 68.1 | ICU 69.1
--------------------- | -------- | -------- | -------- | ---------- | -------- | -------- | --------
-0.2                  |    ✅    |    ✅    |    ✅    |    ✅      |    ✅    |    ✅    |
-0.3                  |    ✅    |    ✅    |    ✅    |    ✅      |    ✅    |    ✅    |
-0.4                  |    ✅    |    ✅    |    ✅    |    ✅      |    ✅    |    ✅    |
-0.5                  |    ✅    |          |          |            |    ✅    |    ✅    |    ✅
----                  |   ---    |    ---   |   ---    |   ---      |   ---    |   ---    |    ✅
-1.0                  |    ✅    |          |          |            |    ✅    |    ✅    |    ✅
+`rust_icu` version     | ICU 63.x | ICU 67.1 | ICU 68.1 | ICU 69.1 | ICU 70.1
+-------------------- | -------- | -------- | -------- | -------- | -------
+0.5                  |    ✅    |    ✅    |    ✅    |    ✅    |
+---                  |    ---   |    ---   |    ---   |    ---   |
+1.0                  |    ✅    |    ✅    |    ✅    |    ✅    |
+---                  |    ---   |    ---   |    ---   |    ---   |
+2.0                  |    ✅    |          |    ✅    |    ✅    |    ✅
 
-> Prior to a 1.0.0 release, API versions that only differ in the patch version
-> number (0.x.**y**) only should be compatible.
+> If you must use a 0.x relase, please use the release 0.5.  Else, upgrade to
+> 1.0 since 1.0 supports the same ICU versions as 0.5.  If you have an option
+> to do so, upgrade to the latest release as soon as able.
 
 # Features
 

--- a/ecma402_traits/Cargo.toml
+++ b/ecma402_traits/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "ecma402_traits"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Rust implementation of type traits to support ECMA 402 specification in Rust.

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,21 +17,21 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "1.0.3", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "1.0.3", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "1.0.3", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "1.0.3", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "1.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.3", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "1.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.3", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "1.0.3", default-features = false }
-rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "1.0.3", default-features = false }
-rust_icu_utrans = { path = "../rust_icu_utrans", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "2.0.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "2.0.0", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "2.0.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "2.0.0", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "2.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "2.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "2.0.0", default-features = false }
+rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "2.0.0", default-features = false }
+rust_icu_utrans = { path = "../rust_icu_utrans", version = "2.0.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "1.0.3"
+version = "2.0.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -6,25 +6,25 @@ license = "Apache-2.0"
 name = "rust_icu_ecma402"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 ECMA 402 standard implementation in Rust.
 """
 [dependencies]
 anyhow = "1.0.25"
-ecma402_traits = { path = "../ecma402_traits", version = "1.0.3" }
+ecma402_traits = { path = "../ecma402_traits", version = "2.0.0" }
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "1.0.3", default-features = false }
-rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "1.0.3", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "1.0.3", default-features = false }
-rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "2.0.0", default-features = false }
+rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "2.0.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "2.0.0", default-features = false }
+rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.3", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "1.0.3"
+version = "2.0.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_ubrk"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_uchar/Cargo.toml
+++ b/rust_icu_uchar/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uchar"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucnv/Cargo.toml
+++ b/rust_icu_ucnv/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucnv"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,12 +19,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "1.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "2.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uformattable"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,10 +18,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "1.0.3", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "2.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_unorm2/Cargo.toml
+++ b/rust_icu_unorm2/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unorm2"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "1.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "2.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,11 +17,11 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "1.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "2.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unumberformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,12 +18,12 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "1.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "1.0.3", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "2.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "1.0.3"
+version = "2.0.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_utrans"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "1.0.3"
+version = "2.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "1.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "1.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "1.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "1.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "2.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"


### PR DESCRIPTION
The uprev to 2.0.0 is due to the drop for support of ICU 67 and
the introduction of ICU 70.

Issue #223