### PR TITLE
Uncomments the publish target for rust_icu_sys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ endef
 
 # Everyone's dependency.
 publish-rust_icu_sys:
-	#$(call publishfn,rust_icu_sys)
+	$(call publishfn,rust_icu_sys)
 .PHONY: publish-rust_icu_sys
 
 publish-rust_icu: publish-rust_icu_sys


### PR DESCRIPTION
I think at some point I forgot to revert this local change and
accidentally made it a part of a commit.

Fixes #223