### PR TITLE
Wrap ucol_setMaxVariable

### DIFF
--- a/rust_icu_ucol/src/lib.rs
+++ b/rust_icu_ucol/src/lib.rs
@@ -216,6 +216,13 @@ impl UCollator {
         unsafe { versioned_function!(ucol_setStrength)(self.rep.as_ptr(), strength) };
     }
 
+    // Implement `ucol_setMaxVariable`
+    generalized_fallible_setter!(
+        set_max_variable,
+        ucol_setMaxVariable,
+        [max_variable: sys::UColReorderCode,]
+    );
+
     // Implement `ucol_setAttribute`
     generalized_fallible_setter!(
         set_attribute,


### PR DESCRIPTION
The use case is allowing the use of `rust_icu` upstream for fuzzer-based comparison of ICU4X and ICU4C results.