### PR TITLE
Fix the buffer preflight treatment and add tests

### DIFF
--- a/rust_icu_common/src/lib.rs
+++ b/rust_icu_common/src/lib.rs
@@ -260,6 +260,7 @@ macro_rules! buffered_string_method_with_retry {
                         .try_into()
                         .map_err(|e| common::Error::wrapper(e))?) {
 
+                status = common::Error::OK_CODE;
                 assert!(full_len > 0);
                 let full_len: usize = full_len
                     .try_into()

--- a/rust_icu_ulistformatter/src/lib.rs
+++ b/rust_icu_ulistformatter/src/lib.rs
@@ -127,11 +127,12 @@ impl UListFormatter {
             || (common::Error::is_ok(status)
                 && full_len > CAPACITY.try_into().map_err(|e| common::Error::wrapper(e))?)
         {
+            status = common::Error::OK_CODE;
             assert!(full_len > 0);
             let full_len: usize = full_len.try_into().map_err(|e| common::Error::wrapper(e))?;
             buf.resize(full_len, 0);
             unsafe {
-                assert!(common::Error::is_ok(status));
+                assert!(common::Error::is_ok(status), "status: {:?}", status);
                 versioned_function!(ulistfmt_format)(
                     self.rep.as_ptr(),
                     pointers as *const *const sys::UChar,

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -585,6 +585,16 @@ mod tests {
         Ok(())
     }
 
+    // https://github.com/google/rust_icu/issues/244
+    #[test]
+    fn test_long_language_tag() -> Result<(), Error> {
+        let mut language_tag: String = "und-CO".to_owned();
+        let language_tag_rest = (0..500).map(|_| " ").collect::<String>();
+        language_tag.push_str(&language_tag_rest);
+        let loc = ULoc::for_language_tag(&language_tag)?;
+        Ok(())
+    }
+
     #[test]
     fn test_script() -> Result<(), Error> {
         let loc = ULoc::try_from("sr-Cyrl")?;

--- a/rust_icu_unorm2/src/lib.rs
+++ b/rust_icu_unorm2/src/lib.rs
@@ -123,6 +123,7 @@ impl UNormalizer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_icu_ustring::UChar;
 
     #[test]
     fn test_compose_pair_nfkc() -> Result<(), common::Error> {
@@ -149,6 +150,17 @@ mod tests {
             let result = n.compose_pair(t.p1, t.p2);
             assert_eq!(result, t.ex);
         }
+        Ok(())
+    }
+
+    // https://github.com/google/rust_icu/issues/244
+    #[test]
+    fn test_long_input_string() -> Result<(), common::Error> {
+        let s = (0..67).map(|_| "탐").collect::<String>();
+        let u = UChar::try_from(&s[..]).unwrap();
+        let normalizer = UNormalizer::new_nfd().unwrap();
+        normalizer.normalize_ustring(&u).unwrap();
+
         Ok(())
     }
 }

--- a/rust_icu_ustring/src/lib.rs
+++ b/rust_icu_ustring/src/lib.rs
@@ -84,7 +84,7 @@ macro_rules! buffered_uchar_method_with_retry {
 
             // Requires that any pointers that are passed in are valid.
             let full_len: i32 = unsafe {
-                assert!(common::Error::is_ok(status));
+                assert!(common::Error::is_ok(status), "status: {:?}", status);
                 method_to_call(
                     $($before_arg,)*
                     buf.as_mut_ptr() as *mut sys::UChar,
@@ -101,7 +101,8 @@ macro_rules! buffered_uchar_method_with_retry {
                     full_len > $buffer_capacity
                         .try_into()
                         .map_err(|e| common::Error::wrapper(e))?) {
-
+                
+                status = common::Error::OK_CODE;
                 assert!(full_len > 0);
                 let full_len: usize = full_len
                     .try_into()
@@ -111,7 +112,7 @@ macro_rules! buffered_uchar_method_with_retry {
                 // Same unsafe requirements as above, plus full_len must be exactly the output
                 // buffer size.
                 unsafe {
-                    assert!(common::Error::is_ok(status));
+                    assert!(common::Error::is_ok(status), "status: {:?}", status);
                     method_to_call(
                         $($before_arg,)*
                         buf.as_mut_ptr() as *mut sys::UChar,


### PR DESCRIPTION
The character conversion code uses a two-pass approach for converting
potentially large inputs into various Unicode strings.  The first
pass uses a fixed capacity buffer (often 200 units).  For strings
that happen to be shorter, the conversion succeeds and nothing else
needs to be done.

But for longer strings, the conversion fails, returning a non-OK status
and the size of the buffer that is actually needed.  A second pass then
provides a buffer that's exactly long enough.

That's great and all, but `status` is reused across both calls, and when
the conversion fails, `status` needs to be set back to `OK_CODE` before
the 2nd pass is attempted.

Props for having the assertion that checks for this; but boos for not
actually testing the conversion code with long strings.

Fixes: #244