### PR TITLE
Allow -l and -L in the path where ICU is installed

### DIFF
--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -189,12 +189,9 @@ mod inner {
 
         /// Obtains the needed flags for the linker.
         fn ldflags(&mut self) -> Result<String> {
-            // Replacements needed because of https://github.com/rust-lang/cargo/issues/7217
-            let result = self
-                .rep
+            self.rep
                 .run(&["--libs", "icu-i18n"])
-                .with_context(|| "could not get the ld flags")?;
-            Ok(result.replace("-L", "-L ").replace("-l", "-l "))
+                .with_context(|| "could not get the ld flags")
         }
 
         /// Obtains the needed flags for the C++ compiler.


### PR DESCRIPTION
Hiya,

It seems `rust_icu` doesn't build when the path to ICU contains the string `-l`, such as when it's in `~/my-libs/icu`. This is because we run `pkg-config --libs icu-i18n` to get the linker flags, and we `str::replace` on it to turn `-Lpath` into `-L path` (to [placate Cargo](https://github.com/rust-lang/cargo/issues/7217)):

```rust
/// Obtains the needed flags for the linker.
fn ldflags(&mut self) -> Result<String> {
	// Replacements needed because of https://github.com/rust-lang/cargo/issues/7217
	let result = self
		.rep
		.run(&["--libs", "icu-i18n"])
		.with_context(|| "could not get the ld flags")?;
	Ok(result.replace("-L", "-L ").replace("-l", "-l "))
}
```

https://github.com/rust-lang/cargo/issues/7217 was fixed in https://github.com/rust-lang/cargo/commit/cfdf00ea9dd2ed25c65da83641eb6838b3b00a3c, which seems to have landed in Rust 1.40 in August 2019, so I think this workaround now does more harm than good. I propose to just remove the `.replace`s. Locally this works just fine. 

I investigated a fix that uses the `regex` crate instead, but `regex` also needs Rust 1.41.1 so that doesn't help much.
