### PR TITLE
Fix use of metavars in doc comments

### DIFF
--- a/rust_icu_common/src/lib.rs
+++ b/rust_icu_common/src/lib.rs
@@ -172,7 +172,7 @@ impl Into<std::fmt::Error> for Error {
 macro_rules! simple_drop_impl {
     ($type_name:ty, $impl_function_name:ident) => {
         impl Drop for $type_name {
-            /// Implements `$impl_function_name`.
+            #[doc = concat!("Implements `", stringify!($impl_function_name), "`.")]
             fn drop(&mut self) {
                 unsafe {
                     versioned_function!($impl_function_name)(self.rep.as_ptr());
@@ -329,7 +329,7 @@ macro_rules! buffered_string_method_with_retry {
 #[macro_export]
 macro_rules! format_ustring_for_type{
     ($method_name:ident, $function_name:ident, $type_decl:ty) => (
-        /// Implements `$function_name`.
+        #[doc = concat!("Implements `", stringify!($function_name), "`.")]
         pub fn $method_name(&self, number: $type_decl) -> Result<String, common::Error> {
             let result = paste::item! {
                 self. [< $method_name _ustring>] (number)?
@@ -340,7 +340,7 @@ macro_rules! format_ustring_for_type{
         // Should be able to use https://github.com/google/rust_icu/pull/144 to
         // make this even shorter.
         paste::item! {
-            /// Implements `$function_name`.
+            #[doc = concat!("Implements `", stringify!($function_name), "`.")]
             pub fn [<$method_name _ustring>] (&self, param: $type_decl) -> Result<ustring::UChar, common::Error> {
                 const CAPACITY: usize = 200;
                 buffered_uchar_method_with_retry!(
@@ -399,7 +399,7 @@ macro_rules! format_ustring_for_type{
 #[macro_export]
 macro_rules! generalized_fallible_getter{
     ($top_level_method_name:ident, $impl_name:ident, [ $( $arg:ident: $arg_type:ty ,)* ],  $ret_type:ty) => (
-        /// Implements `$impl_name`.
+        #[doc = concat!("Implements `", stringify!($impl_name), "`.")]
         pub fn $top_level_method_name(&self, $( $arg: $arg_type, )* ) -> Result<$ret_type, common::Error> {
             let mut status = common::Error::OK_CODE;
             let result: $ret_type = unsafe {

--- a/rust_icu_uformattable/src/lib.rs
+++ b/rust_icu_uformattable/src/lib.rs
@@ -61,7 +61,8 @@ impl<'a> Drop for crate::UFormattable<'a> {
 /// * `$method_name` is an identifier
 macro_rules! simple_getter {
     ($method_name:ident, $impl_function_name:ident, $return_type:ty) => {
-        /// Implements `$impl_function_name`
+        #[doc = concat!("Implements `", stringify!($impl_function_name), "`.")]
+        ///
         /// Use [UFormattable::get_type] to verify that the type matches.
         pub fn $method_name(&self) -> Result<$return_type, common::Error> {
             let mut status = common::Error::OK_CODE;

--- a/rust_icu_unum/src/lib.rs
+++ b/rust_icu_unum/src/lib.rs
@@ -61,13 +61,13 @@ macro_rules! attribute{
     ($method_name:ident, $original_method_name:ident, $type_name:ty) => (
 
         paste::item! {
-            /// Implements `$original_method_name`. Since 0.3.1.
+            #[doc = concat!("Implements `", stringify!($original_method_name), "`. Since 0.3.1.")]
             pub fn [< get_ $method_name >](&self, attr: sys::UNumberFormatAttribute) -> $type_name {
                 unsafe {
                     versioned_function!([< unum_get $original_method_name >])(self.rep.as_ptr(), attr)
                 }
             }
-            /// Implements `$original_method_name`. Since 0.3.1.
+            #[doc = concat!("Implements `", stringify!($original_method_name), "`. Since 0.3.1.")]
             pub fn [< set_ $method_name >](&mut self, attr: sys::UNumberFormatAttribute, value: $type_name) {
                 unsafe {
                     versioned_function!([< unum_set $original_method_name >])(self.rep.as_ptr(), attr, value)

--- a/rust_icu_unumberformatter/src/lib.rs
+++ b/rust_icu_unumberformatter/src/lib.rs
@@ -29,7 +29,7 @@ use {
 
 macro_rules! format_type {
     ($method_name:ident, $impl_function_name:ident, $value_type:ty) => {
-        /// Implements `$impl_function_name`. Since 0.3.1.
+        #[doc = concat!("Implements `", stringify!($impl_function_name), "`. Since 0.3.1.")]
         pub fn $method_name(&self, value: $value_type) -> Result<UFormattedNumber, common::Error> {
             let mut result = UFormattedNumber::try_new()?;
             let mut status = sys::UErrorCode::U_ZERO_ERROR;


### PR DESCRIPTION
Metavars don’t work in doc comments, as can be seen on docs.rs on [methods like this one](https://docs.rs/rust_icu_ucol/latest/rust_icu_ucol/struct.UCollator.html#method.set_max_variable). This can be fixed by using a manual `#[doc]` attribute with `concat!` and `stringify!`,