### PR TITLE
 Uprev rust_icu to 3.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,34 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        icu_version: [63, 69, 70, 71, 72]
+        icu_version: [63, 70, 71, 72]
     steps:
       - uses: actions/checkout@v2
       - name: 'Test ICU version ${{ matrix.icu_version }}'
         run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version}} docker-test'
-  test-nondefault-features:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        icu_version: [63]
-        feature_set:
-          - "renaming,icu_version_in_env,icu_version_69_max"
-    steps:
-      - uses: actions/checkout@v2
-      - name: 'Test ICU version ${{ matrix.icu_version }}'
-        run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version }} RUST_ICU_MAJOR_VERSION_NUMBER=${{ matrix.icu_version }} DOCKER_TEST_CARGO_TEST_ARGS="--no-default-features --features ${{ matrix.feature_set }}" docker-test'
-  test-69-plus-features:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        icu_version: [69]
-        feature_set:
-          - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_version_69_max"
-          - "renaming,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_config,use-bindgen,icu_version_69_max"
-    steps:
-      - uses: actions/checkout@v2
-      - name: 'Test ICU version ${{ matrix.icu_version }}'
-        run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version }} RUST_ICU_MAJOR_VERSION_NUMBER=${{ matrix.icu_version }} DOCKER_TEST_CARGO_TEST_ARGS="--no-default-features --features ${{ matrix.feature_set }}" docker-test'
   test-with-features:
     runs-on: ubuntu-latest
     strategy:
@@ -46,6 +23,17 @@ jobs:
         feature_set:
           - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus"
           - "renaming,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_config,use-bindgen"
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Test ICU version ${{ matrix.icu_version }}'
+        run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version }} RUST_ICU_MAJOR_VERSION_NUMBER=${{ matrix.icu_version }} DOCKER_TEST_CARGO_TEST_ARGS="--no-default-features --features ${{ matrix.feature_set }}" docker-test'
+  test-nondefault-features:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        icu_version: [63]
+        feature_set:
+          - "renaming,icu_version_in_env,icu_version_69_max"
     steps:
       - uses: actions/checkout@v2
       - name: 'Test ICU version ${{ matrix.icu_version }}'

--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,11 @@ endef
 ## Targets for publishing crates to crates.io
 
 # Everyone's dependency.
-publish-rust_icu_sys:
+publish-rust_icu_sys.stamp:
 	$(call publishfn,rust_icu_sys)
-.PHONY: publish-rust_icu_sys
+	touch $@
 
-publish-rust_icu: publish-rust_icu_sys
+publish-rust_icu.stamp: publish-rust_icu_sys.stamp
 	$(call publishfn,rust_icu_common)
 	$(call publishfn,rust_icu_uenum)
 	$(call publishfn,rust_icu_ustring)
@@ -153,25 +153,28 @@ publish-rust_icu: publish-rust_icu_sys
 	$(call publishfn,rust_icu_unorm2)
 	$(call publishfn,rust_icu_uchar)
 	$(call publishfn,rust_icu_ucnv)
-.PHONY: publish-rust_icu
+	touch $@
 
-publish-ecma402_traits:
+publish-ecma402_traits.stamp:
 	$(call publishfn,ecma402_traits)
-.PHONY: publish-ecma402_traits
+	touch $@
 
-publish-rust_icu_ecma402: publish-rust_icu publish-ecma402_traits
+publish-rust_icu_ecma402.stamp: publish-rust_icu.stamp publish-ecma402_traits.stamp
 	$(call publishfn,rust_icu_ecma402)
-.PHONY: publish-rust_icu_ecma402
+	touch $@
 
-publish: publish-rust_icu publish-rust_icu_ecma402
+publish.stamp: publish-rust_icu.stamp publish-rust_icu_ecma402.stamp
 	$(call publishfn,rust_icu)
+	touch $@
+
+publish: publish.stamp
 .PHONY: publish
 
 # A helper to up-rev the cargo crate versions.
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
-UPREV_OLD_VERSION ?= 2.0.3
-UPREV_NEW_VERSION ?= 2.0.4
+UPREV_OLD_VERSION ?= 3.0.0
+UPREV_NEW_VERSION ?= 3.0.1
 define uprevfn
 	( \
 		cd $(1) && \

--- a/README.md
+++ b/README.md
@@ -115,12 +115,9 @@ The compatibility guarantee is as follows:
 
 `rust_icu` version   | ICU 63.x | ICU 67.1 | ICU 68.1 | ICU 69.1 | ICU 70.1 | ICU 71.1 | ICU 72.1 |
 -------------------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
-0.5                  |    ✅    |    ✅    |    ✅    |    ✅    |          |          |          |
 1.0                  |    ✅    |    ✅    |    ✅    |    ✅    |          |          |          |
 2.0                  |    ✅    |          |    ✅    |    ✅    |    ✅    |    ✅    |          |
-
-> If you must use a 0.x relase, please use the release 0.5.  Otherwise, we
-> recommend using the newest release that supports your use case.
+3.0                  |    ✅    |          |          |          |    ✅    |    ✅    |    ✅    |
 
 # Features
 

--- a/ecma402_traits/Cargo.toml
+++ b/ecma402_traits/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "ecma402_traits"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Rust implementation of type traits to support ECMA 402 specification in Rust.

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,21 +17,21 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "2.0.3", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "2.0.3", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "2.0.3", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "2.0.3", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "2.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.3", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "2.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.3", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "2.0.3", default-features = false }
-rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "2.0.3", default-features = false }
-rust_icu_utrans = { path = "../rust_icu_utrans", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "3.0.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "3.0.0", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "3.0.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "3.0.0", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "3.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "3.0.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "3.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "3.0.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "3.0.0", default-features = false }
+rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "3.0.0", default-features = false }
+rust_icu_utrans = { path = "../rust_icu_utrans", version = "3.0.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "2.0.3"
+version = "3.0.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -6,25 +6,25 @@ license = "Apache-2.0"
 name = "rust_icu_ecma402"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 ECMA 402 standard implementation in Rust.
 """
 [dependencies]
 anyhow = "1.0.25"
-ecma402_traits = { path = "../ecma402_traits", version = "2.0.3" }
+ecma402_traits = { path = "../ecma402_traits", version = "3.0.0" }
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "2.0.3", default-features = false }
-rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "2.0.3", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "2.0.3", default-features = false }
-rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "3.0.0", default-features = false }
+rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "3.0.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "3.0.0", default-features = false }
+rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "3.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.3", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "3.0.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "2.0.3"
+version = "3.0.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_ubrk"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_uchar/Cargo.toml
+++ b/rust_icu_uchar/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uchar"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucnv/Cargo.toml
+++ b/rust_icu_ucnv/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucnv"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,12 +19,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "2.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "3.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "3.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uformattable"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,10 +18,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "2.0.3", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "3.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_unorm2/Cargo.toml
+++ b/rust_icu_unorm2/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unorm2"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "2.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "3.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "3.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,11 +17,11 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "2.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "3.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unumberformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,12 +18,12 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "2.0.3", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "2.0.3", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "3.0.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "3.0.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "2.0.3"
+version = "3.0.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_utrans"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "2.0.3"
+version = "3.0.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "2.0.3", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "2.0.3", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "2.0.3", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "2.0.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "3.0.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "3.0.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "3.0.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "3.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"


### PR DESCRIPTION
- 3.0.0 brings support for ICU 72.1
- Dropped support for ICU 68.1, and ICU 69.1, they are out of support
  window.
- Dropped `rust_icu` 0.5, it is out of support window.