### PR TITLE
Update buildenv to rust 1.71.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 #   make USED_BUILDENV_VERSION=whatever-you-want docker-test
 #
 # NOTE: This version number is completely independent of the crate version.
-USED_BUILDENV_VERSION ?= 1.73.0
+USED_BUILDENV_VERSION ?= 1.73.1
 
 CARGO_FEATURE_VERSION :=
 

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -1,5 +1,5 @@
 # rust_icu_buildenv.
-FROM rust:1.56 AS buildenv
+FROM rust:1.71.0 AS buildenv
 
 RUN mkdir -p /src
 
@@ -26,7 +26,7 @@ cargo version && \
 rustup component add rustfmt
 
 RUN \
-cargo install --force --version 0.59.2 bindgen
+cargo install --force --version 0.66.1 bindgen-cli
 
 RUN chmod --recursive a+rwx $HOME
 RUN echo $HOME && cd && ls -ld $HOME

--- a/build/Dockerfile.testenv
+++ b/build/Dockerfile.testenv
@@ -21,7 +21,7 @@ RUN mkdir -p $RUST_ICU_SOURCE_DIR && \
 COPY entrypoint.sh /entrypoint.sh 
 RUN chmod a+rwx /entrypoint.sh
 
-RUN cargo install --force --version 0.59.2 bindgen
+RUN cargo install --force --version 0.66.1 bindgen-cli
 
 ENV CARGO_TEST_ARGS=""
 ENV RUST_ICU_MAJOR_VERSION_NUMBER=""


### PR DESCRIPTION
This handles the issue with some dependencies dropping support for older rust versions.

See https://github.com/google/rust_icu/pull/274 for details.

Issue: #276