### PR TITLE
Adds a once-per-week scheduled run for the build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: "43 7 * * 0"
 
 jobs:
   test-default-features:


### PR DESCRIPTION
This might allow us to catch bitrot issues early.

Bitrot is fixed in https://github.com/google/rust_icu/pull/277, so this probably needs to wait until that PR is merged.