### PR TITLE
fixup: Adds a test run for static-bindgen

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: 'Test ICU version ${{ matrix.icu_version }}'
         run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version }} RUST_ICU_MAJOR_VERSION_NUMBER=${{ matrix.icu_version }} DOCKER_TEST_CARGO_TEST_ARGS="--no-default-features --features ${{ matrix.feature_set }}" docker-test'
+  test-bindgen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Test static-bindgen'
+        run: 'make static-bindgen'

--- a/Makefile
+++ b/Makefile
@@ -85,11 +85,10 @@ static-bindgen-%.stamp: rust_icu_sys/bindgen/run_bindgen.sh
 	docker run ${TTY} \
 			--user=${UID}:${GID} \
 			--volume=${TOP_DIR}:/src/rust_icu \
-			--volume=${LOGNAME_HOME}/.cargo:/usr/local/cargo \
 			--env="RUST_ICU_MAJOR_VERSION_NUMBER=$*" \
 			--entrypoint="/bin/bash" \
 			${DOCKER_REPO}/rust_icu_testenv-$*:${USED_BUILDENV_VERSION} \
-			  "-c" "env OUTPUT_DIR=./rust_icu/rust_icu_sys/bindgen \
+			  "-l" "-c" "env OUTPUT_DIR=./rust_icu/rust_icu_sys/bindgen \
 			  ./rust_icu/rust_icu_sys/bindgen/run_bindgen.sh"
 	touch $@
 


### PR DESCRIPTION
Modifies the github workflow to add a static bindgen run.

Lately we had issues with running that command locally and I realized there are no workflows that exercise it.
That's the `make static-bindgen`.