### PR TITLE
feat: support UDataMemory::open

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,8 +220,8 @@ publish: publish.stamp
 # A helper to up-rev the cargo crate versions.
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
-UPREV_OLD_VERSION ?= 4.0.0
-UPREV_NEW_VERSION ?= 4.1.0
+UPREV_OLD_VERSION ?= 4.2.0
+UPREV_NEW_VERSION ?= 4.3.0
 define uprevfn
 	( \
 		cd $(1) && \

--- a/ecma402_traits/Cargo.toml
+++ b/ecma402_traits/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "ecma402_traits"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Rust implementation of type traits to support ECMA 402 specification in Rust.

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,22 +17,22 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "4.1.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.1.0", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "4.1.0", default-features = false }
-rust_icu_ucsdet = { path = "../rust_icu_ucsdet", version = "4.1.0", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "4.1.0", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "4.1.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.1.0", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.1.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.1.0", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.1.0", default-features = false }
-rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "4.1.0", default-features = false }
-rust_icu_utrans = { path = "../rust_icu_utrans", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "4.2.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.0", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "4.2.0", default-features = false }
+rust_icu_ucsdet = { path = "../rust_icu_ucsdet", version = "4.2.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.0", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "4.2.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.0", default-features = false }
+rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "4.2.0", default-features = false }
+rust_icu_utrans = { path = "../rust_icu_utrans", version = "4.2.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -6,25 +6,25 @@ license = "Apache-2.0"
 name = "rust_icu_ecma402"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 ECMA 402 standard implementation in Rust.
 """
 [dependencies]
 anyhow = "1.0.25"
-ecma402_traits = { path = "../ecma402_traits", version = "4.1.0" }
+ecma402_traits = { path = "../ecma402_traits", version = "4.2.0" }
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.1.0", default-features = false }
-rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "4.1.0", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "4.1.0", default-features = false }
-rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.0", default-features = false }
+rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "4.2.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.0", default-features = false }
+rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "4.2.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.1.0", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_ubrk"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_uchar/Cargo.toml
+++ b/rust_icu_uchar/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uchar"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucnv/Cargo.toml
+++ b/rust_icu_ucnv/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucnv"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ucsdet/Cargo.toml
+++ b/rust_icu_ucsdet/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucsdet"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -16,9 +16,9 @@ ucsdet.h
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,12 +19,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.1.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.1.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udata/src/lib.rs
+++ b/rust_icu_udata/src/lib.rs
@@ -12,29 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+use std::ffi;
+use std::ptr;
+
 use {
     rust_icu_common as common, rust_icu_sys as sys, rust_icu_sys::versioned_function,
-    rust_icu_sys::*, std::convert::TryFrom, std::os::raw,
+    std::convert::TryFrom, std::os::raw,
 };
+
+/// Variants of [UDataMemory].
+#[derive(Debug)]
+enum Rep {
+    /// The data memory is backed by a user-supplied buffer.
+    Buffer(Vec<u8>),
+    /// The data memory is backed by a resource file.
+    Resource(ptr::NonNull<sys::UDataMemory>),
+}
 
 /// Implements `UDataMemory`.
 ///
 /// Represents data memory backed by a borrowed memory buffer used for loading ICU data.
-/// UDataMemory is very much not thread safe, as it affects the global state of the ICU library.
+/// [UDataMemory] is very much not thread safe, as it affects the global state of the ICU library.
 /// This suggests that the best way to use this data is to load it up in a main thread, or access
 /// it through a synchronized wrapper.
 #[derive(Debug)]
 pub struct UDataMemory {
-    // The buffer backing this data memory.  We're holding it here though unused
-    // so that we're sure the underlying buffer won't go away while the data is
-    // in use.
-    #[allow(dead_code)]
-    buf: Vec<u8>,
+    // The internal representation of [UDataMemory].
+    // May vary, depending on the way the struct is created.
+    //
+    // See: [UDataMemory::try_from] and [UDataMemory::open].
+    rep: Rep,
 }
 
 impl Drop for UDataMemory {
     // Implements `u_cleanup`.
     fn drop(&mut self) {
+        if let Rep::Resource(ref r) = self.rep {
+            unsafe {
+                versioned_function!(udata_close)(r.as_ptr())
+            };
+        }
+        // Without this, resource references will remain, but memory will be gone.
         unsafe { versioned_function!(u_cleanup)() };
     }
 }
@@ -56,6 +75,48 @@ impl TryFrom<Vec<u8>> for crate::UDataMemory {
             );
         };
         common::Error::ok_or_warning(status)?;
-        Ok(UDataMemory { buf })
+        Ok(UDataMemory { rep: Rep::Buffer(buf) })
+    }
+}
+
+impl crate::UDataMemory {
+
+    /// Uses the resources from the supplied resource file.
+    ///
+    /// This may end up being more efficient compared to loading from a buffer,
+    /// as ostensibly the resources would be memory mapped to only the needed
+    /// parts.
+    ///
+    /// The `path` is the file path at which to find the resource file.
+    /// The `a_type` is the type of the resource file (can be empty).
+    /// The `name` is the name of the resource file (can also be empty).
+    ///
+    /// Implements `udata_open`.
+    pub fn open(path: &Path, a_type: &str, name: &str) -> Result<Self, common::Error> {
+        let mut status = sys::UErrorCode::U_ZERO_ERROR;
+        let path_cstr = ffi::CString::new(path.to_str().unwrap())?;
+        let name_cstr = ffi::CString::new(name)?;
+        let type_cstr = ffi::CString::new(a_type)?;
+        let raw = unsafe {
+            assert!(common::Error::is_ok(status));
+            // Would be nicer if there were examples of udata_open usage to
+            // verify this.
+            versioned_function!(udata_open)(
+                path_cstr.as_ptr(),
+                if type_cstr.is_empty() {
+                    std::ptr::null()
+                } else {
+                    type_cstr.as_ptr()
+                },
+                if name_cstr.is_empty() {
+                    std::ptr::null()
+                } else {
+                    name_cstr.as_ptr()
+                },
+                &mut status)
+        };
+        common::Error::ok_or_warning(status)?;
+        let rep = ptr::NonNull::new(raw).expect("`raw` must not be null");
+        Ok(crate::UDataMemory{ rep: Rep::Resource(rep)})
     }
 }

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uformattable"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,10 +18,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.1.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_unorm2/Cargo.toml
+++ b/rust_icu_unorm2/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unorm2"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.1.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.1.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,11 +17,11 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.1.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unumberformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,12 +18,12 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.1.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.1.0", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_utrans"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.1.0"
+version = "4.2.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.1.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.1.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.1.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.1.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"


### PR DESCRIPTION
This should be a better way to manage the resource memory, as resources created by `open` are memory
mapped on demand.

Some memory-constrained execution environments may care.