### PR TITLE
Fixup sync send

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ publish-rust_icu.stamp: \
 	$(call publishfn,rust_icu_unorm2)
 	$(call publishfn,rust_icu_uchar)
 	$(call publishfn,rust_icu_ucnv)
+	$(call publishfn,rust_icu_ucsdet)
 	touch $@
 
 publish-ecma402_traits.stamp:

--- a/Makefile
+++ b/Makefile
@@ -221,8 +221,8 @@ publish: publish.stamp
 # A helper to up-rev the cargo crate versions.
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
-UPREV_OLD_VERSION ?= 4.2.0
-UPREV_NEW_VERSION ?= 4.2.1
+UPREV_OLD_VERSION ?= 4.2.2
+UPREV_NEW_VERSION ?= 4.2.3
 define uprevfn
 	( \
 		cd $(1) && \

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ publish: publish.stamp
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
 UPREV_OLD_VERSION ?= 4.2.0
-UPREV_NEW_VERSION ?= 4.3.0
+UPREV_NEW_VERSION ?= 4.2.1
 define uprevfn
 	( \
 		cd $(1) && \

--- a/Makefile
+++ b/Makefile
@@ -221,8 +221,8 @@ publish: publish.stamp
 # A helper to up-rev the cargo crate versions.
 # NOTE: The cargo crate version number is completely independent of the Docker
 # build environment version number.
-UPREV_OLD_VERSION ?= 4.2.2
-UPREV_NEW_VERSION ?= 4.2.3
+UPREV_OLD_VERSION ?= 4.2.3
+UPREV_NEW_VERSION ?= 4.2.4
 define uprevfn
 	( \
 		cd $(1) && \

--- a/ecma402_traits/Cargo.toml
+++ b/ecma402_traits/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "ecma402_traits"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Rust implementation of type traits to support ECMA 402 specification in Rust.

--- a/ecma402_traits/Cargo.toml
+++ b/ecma402_traits/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "ecma402_traits"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Rust implementation of type traits to support ECMA 402 specification in Rust.

--- a/ecma402_traits/Cargo.toml
+++ b/ecma402_traits/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "ecma402_traits"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Rust implementation of type traits to support ECMA 402 specification in Rust.

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,22 +17,22 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "4.2.2", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.2", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "4.2.2", default-features = false }
-rust_icu_ucsdet = { path = "../rust_icu_ucsdet", version = "4.2.2", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.2", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "4.2.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.2", default-features = false }
-rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "4.2.2", default-features = false }
-rust_icu_utrans = { path = "../rust_icu_utrans", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "4.2.3", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.3", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "4.2.3", default-features = false }
+rust_icu_ucsdet = { path = "../rust_icu_ucsdet", version = "4.2.3", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.3", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "4.2.3", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.3", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.3", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.3", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.3", default-features = false }
+rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "4.2.3", default-features = false }
+rust_icu_utrans = { path = "../rust_icu_utrans", version = "4.2.3", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,22 +17,22 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "4.2.1", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.1", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "4.2.1", default-features = false }
-rust_icu_ucsdet = { path = "../rust_icu_ucsdet", version = "4.2.1", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.1", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "4.2.1", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.1", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.1", default-features = false }
-rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "4.2.1", default-features = false }
-rust_icu_utrans = { path = "../rust_icu_utrans", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "4.2.2", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.2", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "4.2.2", default-features = false }
+rust_icu_ucsdet = { path = "../rust_icu_ucsdet", version = "4.2.2", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.2", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "4.2.2", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.2", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.2", default-features = false }
+rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "4.2.2", default-features = false }
+rust_icu_utrans = { path = "../rust_icu_utrans", version = "4.2.2", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,22 +17,22 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "4.2.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.0", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "4.2.0", default-features = false }
-rust_icu_ucsdet = { path = "../rust_icu_ucsdet", version = "4.2.0", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.0", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "4.2.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.0", default-features = false }
-rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "4.2.0", default-features = false }
-rust_icu_utrans = { path = "../rust_icu_utrans", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "4.2.1", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.1", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "4.2.1", default-features = false }
+rust_icu_ucsdet = { path = "../rust_icu_ucsdet", version = "4.2.1", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.1", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "4.2.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.1", default-features = false }
+rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "4.2.1", default-features = false }
+rust_icu_utrans = { path = "../rust_icu_utrans", version = "4.2.1", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "4.2.0"
+version = "4.2.1"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "4.2.1"
+version = "4.2.2"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "4.2.2"
+version = "4.2.3"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -6,25 +6,25 @@ license = "Apache-2.0"
 name = "rust_icu_ecma402"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 ECMA 402 standard implementation in Rust.
 """
 [dependencies]
 anyhow = "1.0.25"
-ecma402_traits = { path = "../ecma402_traits", version = "4.2.1" }
+ecma402_traits = { path = "../ecma402_traits", version = "4.2.2" }
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.1", default-features = false }
-rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "4.2.1", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.1", default-features = false }
-rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.2", default-features = false }
+rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "4.2.2", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.2", default-features = false }
+rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "4.2.2", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -6,25 +6,25 @@ license = "Apache-2.0"
 name = "rust_icu_ecma402"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 ECMA 402 standard implementation in Rust.
 """
 [dependencies]
 anyhow = "1.0.25"
-ecma402_traits = { path = "../ecma402_traits", version = "4.2.0" }
+ecma402_traits = { path = "../ecma402_traits", version = "4.2.1" }
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.0", default-features = false }
-rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "4.2.0", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.0", default-features = false }
-rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.1", default-features = false }
+rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "4.2.1", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.1", default-features = false }
+rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "4.2.1", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -6,25 +6,25 @@ license = "Apache-2.0"
 name = "rust_icu_ecma402"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 ECMA 402 standard implementation in Rust.
 """
 [dependencies]
 anyhow = "1.0.25"
-ecma402_traits = { path = "../ecma402_traits", version = "4.2.2" }
+ecma402_traits = { path = "../ecma402_traits", version = "4.2.3" }
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.2", default-features = false }
-rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "4.2.2", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.2", default-features = false }
-rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "4.2.3", default-features = false }
+rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "4.2.3", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.3", default-features = false }
+rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "4.2.3", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.3", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "4.2.2"
+version = "4.2.3"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "4.2.0"
+version = "4.2.1"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "4.2.1"
+version = "4.2.2"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_ubrk"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_ubrk"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_ubrk"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_uchar/Cargo.toml
+++ b/rust_icu_uchar/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uchar"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uchar/Cargo.toml
+++ b/rust_icu_uchar/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uchar"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uchar/Cargo.toml
+++ b/rust_icu_uchar/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uchar"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucnv/Cargo.toml
+++ b/rust_icu_ucnv/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucnv"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucnv/Cargo.toml
+++ b/rust_icu_ucnv/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucnv"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucnv/Cargo.toml
+++ b/rust_icu_ucnv/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucnv"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ucsdet/Cargo.toml
+++ b/rust_icu_ucsdet/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucsdet"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -16,9 +16,9 @@ ucsdet.h
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucsdet/Cargo.toml
+++ b/rust_icu_ucsdet/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucsdet"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -16,9 +16,9 @@ ucsdet.h
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucsdet/Cargo.toml
+++ b/rust_icu_ucsdet/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucsdet"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -16,9 +16,9 @@ ucsdet.h
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.3", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,12 +19,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.3", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.3", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,12 +19,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.1", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.2", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,12 +19,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udata/src/lib.rs
+++ b/rust_icu_udata/src/lib.rs
@@ -40,6 +40,48 @@ enum Rep {
 unsafe impl Send for Rep {}
 unsafe impl Sync for Rep {}
 
+/// Sets the directory from which to load ICU data resources.
+///
+/// Implements `u_setDataDirectory`.
+pub fn set_data_directory(dir: &Path) {
+    let dir_cstr = ffi::CString::new
+        (dir.to_str().expect("this should never be a runtime error"))
+        .expect("this should never be a runtim error");
+    unsafe {
+        versioned_function!(u_setDataDirectory)(dir_cstr.as_ptr())
+    };
+}
+
+/// The type of the ICU resource requested.  Some standard resources have their
+/// canned types. In case you run into one that is not captured here, use [Custom],
+/// and consider sending a pull request to add the new resource type.
+pub enum Type {
+    /// An empty resource type. This is ostensibly allowed, but unclear when
+    /// it is applicable.
+    Empty,
+    /// The unpacked resource type, equivalent to "res" in ICU4C.
+    Res,
+    /// The cnv resource type, equivalent to "cnv" in ICU4C.
+    Cnv,
+    /// The "common" data type, equivalent to "dat" in ICU4C.
+    Dat,
+    /// A custom data type, in case none of the above fit your use case. It
+    /// is not clear whether this would ever be useful, but the ICU4C API
+    /// allows for it, so we must too.
+    Custom(String),
+}
+
+impl AsRef<str> for Type {
+    fn as_ref(&self) -> &str {
+        match self {
+            Type::Empty => &"",
+            Type::Res => &"res",
+            Type::Dat => &"dat",
+            Type::Cnv => &"cnv",
+            Type::Custom(ref s) => &s,
+        }
+    }
+}
 
 /// Implements `UDataMemory`.
 ///
@@ -103,16 +145,35 @@ impl crate::UDataMemory {
     /// as ostensibly the resources would be memory mapped to only the needed
     /// parts.
     ///
-    /// The `path` is the file path at which to find the resource file.
-    /// The `a_type` is the type of the resource file (can be empty).
-    /// The `name` is the name of the resource file (can also be empty).
+    /// - The `path` is the file path at which to find the resource file. Ostensibly
+    /// specifying `None` here will load from the "default" ICU_DATA path.
+    /// I have not been able to confirm this.
+    ///
+    /// - The `a_type` is the type of the resource file. It is not clear whether
+    /// the resource file type is a closed or open set, so we provide for both
+    /// possibilities.
+    ///
+    /// - The `name` is the name of the resource file. It is documented nullable
+    ///   in the ICU documentation. Pass `None` here to pass nullptr to the
+    ///   underlying C API.
+    ///
+    /// Presumably using `UDataMemory::open(Some("/dir/too"), Type::Res, Some("filename")` would
+    /// attempt to load ICU data from `/dir/too/filename.res`, as well as some other
+    /// canonical permutations of the above.  The full documentation is
+    /// [here][1], although I could not confirm that the documentation is actually
+    /// describing what the code does.  Also, using `None` at appropriate places
+    /// seems to be intended to load data from [some "default" sites][2]. I have
+    /// however observed that the actual behavior diverges from that documentation.
     ///
     /// Implements `udata_open`.
-    pub fn open(path: &Path, a_type: &str, name: &str) -> Result<Self, common::Error> {
+    ///
+    /// [1]: https://unicode-org.github.io/icu/userguide/icu_data/#how-data-loading-works
+    /// [2]: https://unicode-org.github.io/icu/userguide/icu_data/#icu-data-directory
+    pub fn open(path: Option<&Path>, a_type: Type, name: Option<&str>) -> Result<Self, common::Error> {
         let mut status = sys::UErrorCode::U_ZERO_ERROR;
-        let path_cstr = ffi::CString::new(path.to_str().unwrap())?;
-        let name_cstr = ffi::CString::new(name)?;
-        let type_cstr = ffi::CString::new(a_type)?;
+        let path_cstr = path.map(|s| { ffi::CString::new(s.to_str().expect("should never be a runtime error")).unwrap()});
+        let name_cstr = name.map(|s| { ffi::CString::new(s).expect("should never be a runtime error") } );
+        let type_cstr = ffi::CString::new(a_type.as_ref()).expect("should never be a runtime errror");
         let rep = unsafe {
             // Safety: we do what we must to call the underlying unsafe C API, and only return an
             // opaque enum, to ensure that no rust client code may touch the raw pointer.
@@ -121,17 +182,9 @@ impl crate::UDataMemory {
             // Would be nicer if there were examples of udata_open usage to
             // verify this.
             let rep: *const sys::UDataMemory = versioned_function!(udata_open)(
-                path_cstr.as_ptr(),
-                if type_cstr.is_empty() {
-                    std::ptr::null()
-                } else {
-                    type_cstr.as_ptr()
-                },
-                if name_cstr.is_empty() {
-                    std::ptr::null()
-                } else {
-                    name_cstr.as_ptr()
-                },
+                path_cstr.map(|s| s.as_ptr()).unwrap_or(std::ptr::null()),
+                type_cstr.as_ptr(),
+                name_cstr.map(|c| c.as_ptr()).unwrap_or(std::ptr::null()),
                 &mut status);
             // Sadly we can not use NonNull, as we can not make the resulting
             // type Sync or Send.

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uformattable"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uformattable"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uformattable"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,10 +18,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,10 +18,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,10 +18,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.1", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.2", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.2", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.3", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_unorm2/Cargo.toml
+++ b/rust_icu_unorm2/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unorm2"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.1", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.2", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_unorm2/Cargo.toml
+++ b/rust_icu_unorm2/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unorm2"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_unorm2/Cargo.toml
+++ b/rust_icu_unorm2/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unorm2"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "4.2.3", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.3", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,11 +17,11 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,11 +17,11 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.3", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,11 +17,11 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.1", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.2", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unumberformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,12 +18,12 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.1", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.2", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unumberformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,12 +18,12 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.2", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.2", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.3", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.3", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unumberformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,12 +18,12 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.0", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "4.2.1", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "4.2.1", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "4.2.1"
+version = "4.2.2"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "4.2.2"
+version = "4.2.3"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "4.2.0"
+version = "4.2.1"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_utrans"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.2"
+version = "4.2.3"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.3", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.3", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.3", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.3", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_utrans"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.1"
+version = "4.2.2"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.2", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.2", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.2", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.2", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_utrans"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "4.2.0"
+version = "4.2.1"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "4.2.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "4.2.1", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "4.2.1", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "4.2.1", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "4.2.1", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"


### PR DESCRIPTION
The implementation of UDataMemory via NonNull prevented using
UDataMemory in threaded contexts. Now, in general this is correct.
But in our case, there is no other way to use the data in threaded
context except through the C++ library which requires holding a pointer.
So...

Issue: #282