### PR TITLE
chore: remove statements causing warnings

### DIFF
--- a/rust_icu_sys/src/lib.rs
+++ b/rust_icu_sys/src/lib.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![doc(test(ignore))]
 
 // Notes:
 // * deref_nullptr: since rustc 1.53, bindgen causes UB warnings -- see

--- a/rust_icu_uchar/src/lib.rs
+++ b/rust_icu_uchar/src/lib.rs
@@ -24,7 +24,6 @@ use {
     rust_icu_common as common,
     rust_icu_sys as sys,
     rust_icu_sys::versioned_function,
-    rust_icu_sys::*,
     std::ffi,
 };
 

--- a/rust_icu_ucnv/src/lib.rs
+++ b/rust_icu_ucnv/src/lib.rs
@@ -42,7 +42,6 @@ use std::{
 
 use {
     rust_icu_common as common, rust_icu_sys as sys, rust_icu_sys::versioned_function,
-    rust_icu_sys::*,
 };
 
 pub mod utf8;

--- a/rust_icu_ucnv/src/utf8.rs
+++ b/rust_icu_ucnv/src/utf8.rs
@@ -14,7 +14,7 @@
 
 use {
     rust_icu_common as common, rust_icu_sys as sys, rust_icu_sys::versioned_function,
-    rust_icu_sys::*, std::ops::Range, std::os::raw,
+    std::ops::Range, std::os::raw,
 };
 
 use super::{FeedConverterRaw, FeedResult, UConverter};

--- a/rust_icu_ucol/src/lib.rs
+++ b/rust_icu_ucol/src/lib.rs
@@ -71,7 +71,6 @@ use {
     rust_icu_common::simple_drop_impl,
     rust_icu_sys as sys,
     rust_icu_sys::versioned_function,
-    rust_icu_sys::*,
     rust_icu_uenum as uenum, rust_icu_ustring as ustring,
     std::{cmp::Ordering, convert::TryFrom, ffi, ptr},
 };

--- a/rust_icu_udat/src/lib.rs
+++ b/rust_icu_udat/src/lib.rs
@@ -23,7 +23,7 @@
 
 use {
     rust_icu_common as common, rust_icu_sys as sys, rust_icu_sys::versioned_function,
-    rust_icu_sys::*, rust_icu_ucal as ucal, rust_icu_uloc as uloc, rust_icu_ustring as ustring,
+    rust_icu_ucal as ucal, rust_icu_uloc as uloc, rust_icu_ustring as ustring,
 };
 use std::convert::{TryFrom, TryInto};
 
@@ -392,7 +392,7 @@ mod tests {
     fn test_format_default_calendar() -> Result<(), common::Error> {
         #[derive(Debug)]
         struct Test {
-            name: &'static str,
+            _name: &'static str,
             locale: &'static str,
             timezone: &'static str,
             date: sys::UDate,
@@ -401,7 +401,7 @@ mod tests {
         }
         let tests = vec![
             Test {
-                name: "French default",
+                _name: "French default",
                 locale: "fr-FR",
                 timezone: "America/Los_Angeles",
                 date: 100.0,
@@ -410,7 +410,7 @@ mod tests {
                 calendar: None,
             },
             Test {
-                name: "French default, a few hours later",
+                _name: "French default, a few hours later",
                 locale: "fr-FR",
                 timezone: "America/Los_Angeles",
                 date: 100000.0,
@@ -419,7 +419,7 @@ mod tests {
                 calendar: None,
             },
             Test {
-                name: "Serbian default",
+                _name: "Serbian default",
                 locale: "sr-RS",
                 timezone: "America/Los_Angeles",
                 date: 100000.0,
@@ -428,7 +428,7 @@ mod tests {
                 calendar: None,
             },
             Test {
-                name: "Dutch default",
+                _name: "Dutch default",
                 locale: "nl-NL",
                 timezone: "America/Los_Angeles",
                 date: 100000.0,
@@ -436,7 +436,7 @@ mod tests {
                 calendar: None,
             },
             Test {
-                name: "Dutch islamic overrides locale calendar and timezone",
+                _name: "Dutch islamic overrides locale calendar and timezone",
                 locale: "nl-NL-u-ca-gregorian",
                 timezone: "America/Los_Angeles",
                 date: 100000.0,
@@ -451,7 +451,7 @@ mod tests {
                 ),
             },
             Test {
-                name: "Dutch islamic take from locale",
+                _name: "Dutch islamic take from locale",
                 locale: "nl-NL-u-ca-islamic",
                 timezone: "America/Los_Angeles",
                 date: 200000.0,
@@ -459,7 +459,7 @@ mod tests {
                 calendar: None,
             },
             Test {
-                name: "Dutch islamic take from locale",
+                _name: "Dutch islamic take from locale",
                 locale: "nl-NL-u-ca-islamic",
                 timezone: "America/Los_Angeles",
                 date: 200000.0,

--- a/rust_icu_uenum/src/lib.rs
+++ b/rust_icu_uenum/src/lib.rs
@@ -27,7 +27,7 @@ use {
 pub struct Enumeration {
     // The raw underlying character array, in case the underlying char array is
     // owned by this enumeration.
-    raw: Option<common::CStringVec>,
+    _raw: Option<common::CStringVec>,
 
     // Internal low-level representation of the enumeration.  The internal
     // representation relies on `raw` and `len` above and must live at most as
@@ -76,7 +76,7 @@ impl TryFrom<&[&str]> for Enumeration {
         assert!(!rep.is_null());
         Ok(Enumeration {
             rep,
-            raw: Some(raw),
+            _raw: Some(raw),
         })
     }
 }
@@ -136,10 +136,10 @@ impl Enumeration {
     /// create an [Enumeration].
     #[doc(hidden)]
     pub unsafe fn from_raw_parts(
-        raw: Option<common::CStringVec>,
+        _raw: Option<common::CStringVec>,
         rep: *mut sys::UEnumeration,
     ) -> Enumeration {
-        Enumeration { raw, rep }
+        Enumeration { _raw, rep }
     }
 }
 
@@ -157,7 +157,7 @@ pub fn ucal_open_country_time_zones(country: &str) -> Result<Enumeration, common
     };
     common::Error::ok_or_warning(status)?;
     Ok(Enumeration {
-        raw: None,
+        _raw: None,
         rep: raw_enum,
     })
 }
@@ -199,7 +199,7 @@ pub fn ucal_open_time_zone_id_enumeration(
     };
     common::Error::ok_or_warning(status)?;
     Ok(Enumeration {
-        raw: None,
+        _raw: None,
         rep: raw_enum,
     })
 }
@@ -218,7 +218,7 @@ pub fn open_time_zones() -> Result<Enumeration, common::Error> {
     };
     common::Error::ok_or_warning(status)?;
     Ok(Enumeration {
-        raw: None,
+        _raw: None,
         rep: raw_enum,
     })
 }
@@ -240,7 +240,7 @@ pub fn uloc_open_keywords(locale: &str) -> Result<Enumeration, common::Error> {
         Ok(Enumeration::empty())
     } else {
         Ok(Enumeration {
-            raw: None,
+            _raw: None,
             rep: raw_enum,
         })
     }

--- a/rust_icu_uformattable/src/lib.rs
+++ b/rust_icu_uformattable/src/lib.rs
@@ -17,7 +17,6 @@
 use {
     rust_icu_common as common, rust_icu_sys as sys,
     rust_icu_sys::versioned_function,
-    rust_icu_sys::*,
     rust_icu_ustring as ustring,
     std::{convert::TryFrom, ffi, os::raw, ptr},
 };

--- a/rust_icu_ulistformatter/src/lib.rs
+++ b/rust_icu_ulistformatter/src/lib.rs
@@ -31,7 +31,6 @@
 use {
     rust_icu_common as common, rust_icu_sys as sys,
     rust_icu_sys::versioned_function,
-    rust_icu_sys::*,
     rust_icu_ustring as ustring,
     std::{convert::TryFrom, convert::TryInto, ffi, ptr},
 };

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -580,7 +580,7 @@ mod tests {
         let mut language_tag: String = "und-CO".to_owned();
         let language_tag_rest = (0..500).map(|_| " ").collect::<String>();
         language_tag.push_str(&language_tag_rest);
-        let loc = ULoc::for_language_tag(&language_tag)?;
+        let _loc = ULoc::for_language_tag(&language_tag)?;
         Ok(())
     }
 

--- a/rust_icu_unorm2/src/lib.rs
+++ b/rust_icu_unorm2/src/lib.rs
@@ -18,7 +18,6 @@ use {
     rust_icu_common as common,
     rust_icu_sys as sys,
     rust_icu_sys::versioned_function,
-    rust_icu_sys::*, 
     rust_icu_ustring as ustring,
     rust_icu_ustring::buffered_uchar_method_with_retry,
 };

--- a/rust_icu_unum/src/lib.rs
+++ b/rust_icu_unum/src/lib.rs
@@ -24,7 +24,6 @@ use {
     rust_icu_common::simple_drop_impl,
     rust_icu_sys as sys,
     rust_icu_sys::versioned_function,
-    rust_icu_sys::*,
     rust_icu_uformattable as uformattable, rust_icu_uloc as uloc, rust_icu_ustring as ustring,
     rust_icu_ustring::buffered_uchar_method_with_retry,
     std::{convert::TryFrom, convert::TryInto, ptr},

--- a/rust_icu_unumberformatter/src/lib.rs
+++ b/rust_icu_unumberformatter/src/lib.rs
@@ -17,11 +17,10 @@
 //! Since 0.3.1
 
 use {
-    paste, rust_icu_common as common,
+    rust_icu_common as common,
     rust_icu_common::simple_drop_impl,
     rust_icu_sys as sys,
     rust_icu_sys::versioned_function,
-    rust_icu_sys::*,
     rust_icu_uloc as uloc, rust_icu_unum as unum, rust_icu_ustring as ustring,
     rust_icu_ustring::buffered_uchar_method_with_retry,
     std::{convert::TryFrom, convert::TryInto, ptr},


### PR DESCRIPTION
Remove statements which, for some reason, caused older compiler versions to error out.

This doesn't seem to be the case now, and there should be no reason to keep them.