### PR TITLE
fix: use *const c_char cast instead of *const i8

### DIFF
--- a/rust_icu_ucsdet/src/lib.rs
+++ b/rust_icu_ucsdet/src/lib.rs
@@ -37,6 +37,7 @@ use {
         ffi::CStr,
         marker::PhantomData,
         mem::transmute,
+        os::raw::c_char,
         ptr::{self, NonNull},
     },
 };
@@ -87,7 +88,7 @@ impl<'detector> CharsetDetector<'detector> {
         unsafe {
             versioned_function!(ucsdet_setText)(
                 self.rep.as_ptr(),
-                text.as_ptr() as *const i8,
+                text.as_ptr() as *const c_char,
                 text.len() as i32,
                 &mut status,
             );
@@ -101,7 +102,7 @@ impl<'detector> CharsetDetector<'detector> {
         unsafe {
             versioned_function!(ucsdet_setDeclaredEncoding)(
                 self.rep.as_ptr(),
-                encoding.as_ptr() as *const i8,
+                encoding.as_ptr() as *const c_char,
                 encoding.len() as i32,
                 &mut status,
             );


### PR DESCRIPTION
Fixes the build of `rust_icu_ucsdet` for Android targets, since `c_char` is defined a `*const u8`.

```
error[E0308]: mismatched types
  --> external/crate_index__rust_icu_ucsdet-4.2.3/src/lib.rs:90:17
   |
88 |             versioned_function!(ucsdet_setText)(
   |             ----------------------------------- arguments to this function are incorrect
89 |                 self.rep.as_ptr(),
90 |                 text.as_ptr() as *const i8,
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
   |
   = note: expected raw pointer `*const u8`
              found raw pointer `*const i8`
```