### PR TITLE
Link against libc++ on Apple targets

### DIFF
--- a/rust_icu_sys/src/lib.rs
+++ b/rust_icu_sys/src/lib.rs
@@ -87,7 +87,15 @@ extern crate libc;
 #[cfg_attr(feature = "static", link(name = "icui18n", kind = "static"))]
 #[cfg_attr(feature = "static", link(name = "icuuc", kind = "static"))]
 #[cfg_attr(feature = "static", link(name = "icudata", kind = "static"))]
-#[cfg_attr(feature = "static", link(name = "stdc++", kind = "dylib"))]
+// On systems such as macOS, libc++ is the default library
+#[cfg_attr(
+    all(target_vendor = "apple", feature = "static"),
+    link(name = "c++", kind = "dylib")
+)]
+#[cfg_attr(
+    not(all(target_vendor = "apple", feature = "static")),
+    link(name = "stdc++", kind = "dylib")
+)]
 extern "C" {}
 
 impl From<i8> for UCharCategory {


### PR DESCRIPTION
On Apple systems, `libc++` is the default C++ library[^1]. Trying to compile a binary example using `rust_icu` with the `static` feature enabled will currently fail on Apple systems with the following error:

```
  = note: ld: library 'stdc++' not found
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This patch links against `libc++` on Apple and FreeBSD systems when the `static` features is enabled.

Note: maybe adding a CI job that builds on macOS in `static` mode is also a good idea?

[^1]: https://developer.apple.com/xcode/cpp/