### PR TITLE
Move linking flags to build.rs to help with non-cargo build systems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: 'Test static-bindgen'
         run: 'make static-bindgen'
+  test-static-linking:
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - if: matrix.runs-on == 'macos-latest'
+        run: make macos-test
+      - if: matrix.runs-on == 'ubuntu-latest'
+        run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches: [ main ]
   schedule:
     - cron: "43 7 * * 0"
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-default-features:

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ docker-test:
 macos-test:
 	brew install icu4c
 	RUST_ICU_LINK_SEARCH_DIR=$(brew --prefix)/opt/icu4c/lib \
+	RUST_ICU_MAJOR_VERSION_NUMBER=${RUST_ICU_MAJOR_VERSION_NUMBER} \
 	cargo test --no-default-features --features=icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_version_in_env,renaming,static
 .PHONY: macos-test
 

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,13 @@ docker-test:
 			${DOCKER_REPO}/${DOCKER_TEST_ENV}:${USED_BUILDENV_VERSION}
 .PHONY: docker-test
 
+# Test with the homebrew version of icu4c on macOS with static linking (the default way of linking for distribution on Apple platforms)
+macos-test:
+	brew install icu4c
+	RUST_ICU_LINK_SEARCH_DIR=$(brew --prefix)/opt/icu4c/lib \
+	cargo test --no-default-features --features=icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_version_in_env,renaming,static
+.PHONY: macos-test
+
 # Refreshes the static bindgen output (contents of ./rust_icu_sys/bindgen) based
 # on the currently present ICU versions in the test environment.
 #

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ docker-test:
 # Test with the homebrew version of icu4c on macOS with static linking (the default way of linking for distribution on Apple platforms)
 macos-test:
 	brew install icu4c
-	RUST_ICU_LINK_SEARCH_DIR=$(brew --prefix)/opt/icu4c/lib \
+	RUST_ICU_LINK_SEARCH_DIR="$(shell brew --prefix)/opt/icu4c/lib" \
 	RUST_ICU_MAJOR_VERSION_NUMBER=${RUST_ICU_MAJOR_VERSION_NUMBER} \
 	cargo test --no-default-features --features=icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_version_in_env,renaming,static
 .PHONY: macos-test

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Feature              | Default? | Description
 `renaming`           | Yes      | If set, ICU bindings are generated with version numbers appended. This is called "renaming" in ICU, and is normally needed only when linking against specific ICU version is required, for example to work around having to link different ICU versions. See [the ICU documentation](https://unicode-org.github.io/icu/userguide/icu/design.html) for a discussion of renaming. **This feature MUST be used when `bindgen` is NOT used.**
 `icu_config`         | Yes      | If set, the binary icu-config will be used to configure the library. Turn this feature off if you do not want `build.rs` to try to autodetect the build environment. You will want to skip this feature if your build environment configures ICU in a different way. **This feature is only meaningful when `bindgen` feature is used; otherwise it has no effect.**
 `icu_version_in_env` | No       | If set, ICU bindings are made for the ICU version specified in the environment variable `RUST_ICU_MAJOR_VERSION_NUMBER`, which is made available to cargo at build time. See section below for details on how to use this feature. **This feature is only meaningful when `bindgen` feature is NOT used; otherwise it has no effect.**
+`static`             | No       | If set, link ICU libraries statically (and the standard C++ dynamically). You can use `RUST_ICU_LINK_SEARCH_DIR` to add an extra path to the search path if you have a build of ICU in a non-standard directory.
 
 # Prerequisites
 

--- a/rust_icu_sys/src/lib.rs
+++ b/rust_icu_sys/src/lib.rs
@@ -23,7 +23,7 @@
     non_upper_case_globals,
     unused_imports,
     rustdoc::bare_urls,
-    deref_nullptr,
+    deref_nullptr
 )]
 
 #[cfg(all(feature = "icu_version_in_env", feature = "icu_config"))]
@@ -80,24 +80,6 @@ impl std::fmt::Display for UErrorCode {
 
 extern crate libc;
 
-// A "fake" extern used to express link preferences.  The libraries mentioned
-// below will be converted to "-l" flags to the linker.
-#[cfg_attr(not(feature = "static"), link(name = "icui18n", kind = "dylib"))]
-#[cfg_attr(not(feature = "static"), link(name = "icuuc", kind = "dylib"))]
-#[cfg_attr(feature = "static", link(name = "icui18n", kind = "static"))]
-#[cfg_attr(feature = "static", link(name = "icuuc", kind = "static"))]
-#[cfg_attr(feature = "static", link(name = "icudata", kind = "static"))]
-// On systems such as macOS, libc++ is the default library
-#[cfg_attr(
-    all(target_vendor = "apple", feature = "static"),
-    link(name = "c++", kind = "dylib")
-)]
-#[cfg_attr(
-    not(all(target_vendor = "apple", feature = "static")),
-    link(name = "stdc++", kind = "dylib")
-)]
-extern "C" {}
-
 impl From<i8> for UCharCategory {
     fn from(value: i8) -> Self {
         match value {
@@ -132,7 +114,7 @@ impl From<i8> for UCharCategory {
             28 => UCharCategory::U_INITIAL_PUNCTUATION,
             29 => UCharCategory::U_FINAL_PUNCTUATION,
             30 => UCharCategory::U_CHAR_CATEGORY_COUNT,
-            _ => { 
+            _ => {
                 panic!("could not convert: {}", value);
             }
         }


### PR DESCRIPTION
While using `rust_icu` with Bazel, I realized that the `#[cfg_attr]` attributes in the code make everything difficult.

This brings the following improvement:
- Makes it easier to add combination of features to change the flags, since we can use proper branching
- Moving the instructions to the `build.rs` enables building `rust_icu` with Bazel (which can skip using the `build.rs` file)
- Adds the ability to specify the `RUST_ICU_LINK_SEARCH_DIR` environment variable when you need to use a non-installed build of `icu4c`
- Document the `static` feature and add a CI job to test this for both Ubuntu and macOS