### PR TITLE
Set the resolver version to 2, clarify the error message when the ICU…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ members = [
   "rust_icu_utext",
   "rust_icu_utrans",
 ]
+resolver = "2"

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -225,7 +225,7 @@ mod inner {
                         Ok(str)
                     }
                 })
-                .with_context(|| "failed to get ICU version; please ensure icu-config in $PATH")
+                .with_context(|| "failed to get ICU version; please ensure pkg-config in $PATH")
         }
 
         fn install_dir(&mut self) -> Result<String> {

--- a/rust_icu_udat/build.rs
+++ b/rust_icu_udat/build.rs
@@ -76,7 +76,7 @@ mod inner {
         pub fn version(&mut self) -> Result<String> {
             self.rep
                 .run(&["--modversion", "icu-i18n"])
-                .with_context(|| "while getting ICU version; is icu-config in $PATH?")
+                .with_context(|| "while getting ICU version; is pkg-config in $PATH?")
         }
 
         /// Returns the config major number.  For example, will return "64" for

--- a/rust_icu_uloc/build.rs
+++ b/rust_icu_uloc/build.rs
@@ -76,7 +76,7 @@ mod inner {
         pub fn version(&mut self) -> Result<String> {
             self.rep
                 .run(&["--modversion", "icu-i18n"])
-                .with_context(|| "while getting ICU version; is icu-config in $PATH?")
+                .with_context(|| "while getting ICU version; is pkg-config in $PATH?")
         }
 
         /// Returns the config major number.  For example, will return "64" for

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -780,6 +780,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(features = "icu_version_64_plus")]
     #[test]
     fn test_name() -> Result<(), Error> {
         let loc = ULoc::try_from("en-US")?;
@@ -1146,6 +1147,7 @@ mod tests {
         assert_eq!(ULoc::for_language_tag("sr-u-tz-uslax").unwrap(), loc);
     }
 
+    #[cfg(features = "icu_version_64_plus")]
     #[test]
     fn test_for_language_error() {
         let loc = ULoc::for_language_tag("en_US").unwrap();
@@ -1153,6 +1155,7 @@ mod tests {
         assert_eq!(loc.country(), None);
     }
 
+    #[cfg(features = "icu_version_64_plus")]
     #[test]
     fn test_iso3_language() {
         let loc = ULoc::for_language_tag("en-US").unwrap();
@@ -1163,6 +1166,7 @@ mod tests {
         assert_eq!(iso_lang, None);
     }
 
+    #[cfg(features = "icu_version_64_plus")]
     #[test]
     fn test_iso3_country() {
         let loc = ULoc::for_language_tag("en-US").unwrap();
@@ -1173,6 +1177,7 @@ mod tests {
         assert_eq!(iso_country, None);
     }
 
+    #[cfg(features = "icu_version_64_plus")]
     #[test]
     fn test_display_language() {
         let english_locale = ULoc::for_language_tag("en").unwrap();
@@ -1186,6 +1191,7 @@ mod tests {
         assert_eq!(root_locale.display_language(&french_locale).unwrap().as_string_debug(), "langue indéterminée");
     }
 
+    #[cfg(features = "icu_version_64_plus")]
     #[test]
     fn test_display_script() {
         let english_latin_locale = ULoc::for_language_tag("en-latg").unwrap();
@@ -1226,6 +1232,7 @@ mod tests {
         assert_eq!(calendar_value_in_french.unwrap().as_string_debug(), "calendrier hébraïque");
     }
 
+    #[cfg(features = "icu_version_64_plus")]
     #[test]
     fn test_display_name() {
         let loc = ULoc::for_language_tag("az-Cyrl-AZ-u-ca-hebrew-t-it-x-whatever").unwrap();

--- a/rust_icu_ustring/src/lib.rs
+++ b/rust_icu_ustring/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # Implemuntation of the functions in the ICU4C `ustring.h` header.
+//! # Implementation of the functions in the ICU4C `ustring.h` header.
 //!
 //! This is where the UTF-8 strings get converted back and forth to the UChar
 //! representation.


### PR DESCRIPTION
… version isn't found and add implementations for ICU functions:
 - uloc_getName(),
 - uloc_getISO3Language(),
 - uloc_getISO3Country(),
 - uloc_getDisplayLanguage(),
 - uloc_getDisplayScript(),
 - uloc_getDisplayCountry(),
 - uloc_getDisplayVariant(),
 - uloc_getDisplayKeyword(),
 - uloc_getDisplayKeywordValue(), and
 - uloc_getDisplayName()).