### PR TITLE
fix: Improve the accuracy of the coverage report.

### DIFF
--- a/build/showprogress.sh
+++ b/build/showprogress.sh
@@ -29,86 +29,99 @@ C_API_HEADER_NAMES=(
 
 ICU_INCLUDE_PATH="$(icu-config --cppflags-searchpath | sed -e 's/-I//' | sed -e 's/ //g')"
 
-for header_basename in ${C_API_HEADER_NAMES[@]}; do
-  header_fullname="${ICU_INCLUDE_PATH}/unicode/${header_basename}.h"
-  echo $header_basename: $header_fullname
-  ctags -x --c-kinds=fp $header_fullname | sed -e 's/ .*$//' \
-    | grep -v U_DEFINE | sort | uniq \
-    > "${TOP_DIR}/coverage/${header_basename}_all.txt"
-
-  # Extracts all mentions of functions such as "utext_close" for example from
-  # rust docs of the form "/// Implements `utext_close` ... ".  This is
-  # simplistic but quite enough with a little bit of care.
-  find . -path "*rust_icu_${header_basename}/src/*.rs" | \
-    xargs grep "/// Implements \`" | sed -e 's/.*`\(.*\)`.*$/\1/' | sed -e 's/\(.*\)()$/\1/' | \
-    sort | uniq > "${TOP_DIR}/coverage/${header_basename}_implemented.txt"
-done
-
-# Now, write a report out. Again, simplistic, but gets the job done.
+# Write a report out as we read the data.
 
 REPORT_FILE="${TOP_DIR}/coverage/report.md"
-cat <<EOF > "${REPORT_FILE}"
+REPORT_FILE_HEADER="${TOP_DIR}/coverage/report_header.md"
+REPORT_FILE_DETAIL="${TOP_DIR}/coverage/report_detail.md"
+cat <<EOF > "${REPORT_FILE_HEADER}"
 # Implementation coverage report
 
 | Header | Implemented |
 | ------ | ----------- |
 EOF
-for header_basename in ${C_API_HEADER_NAMES[@]}; do
-  total_functions="$(cat "${TOP_DIR}"/coverage/${header_basename}_all.txt | wc -l)"
-  implemented_functions="$(cat "${TOP_DIR}"/coverage/${header_basename}_implemented.txt | wc -l)"
-  printf "| \`%s.h\` | %s / %s | \n" ${header_basename} ${implemented_functions} ${total_functions} >> "${REPORT_FILE}"
-done
 
-cat <<EOF >>"${REPORT_FILE}"
+  cat <<EOF >>"${REPORT_FILE_DETAIL}"
 # Unimplemented functions per header
 
 EOF
+
 for header_basename in ${C_API_HEADER_NAMES[@]}; do
-  cat <<EOF >>"${REPORT_FILE}"
+  : > "${TOP_DIR}/coverage/${header_basename}_all.txt"
+  : > "${TOP_DIR}/coverage/${header_basename}_implemented.txt"
+  header_fullname="${ICU_INCLUDE_PATH}/unicode/${header_basename}.h"
+  all=$(ctags -x --c-kinds=fp $header_fullname | sed -e 's/ .*$//' \
+    | grep -v U_DEFINE | sort -fs | uniq)
+  for fn in ${all}; do
+    printf "%s\n" ${fn} >> "${TOP_DIR}/coverage/${header_basename}_all.txt"
+  done
+
+  # Extracts all mentions of functions such as "utext_close" for example from
+  # rust docs of the form "/// Implements `utext_close` ... ".  This is
+  # simplistic but quite enough with a little bit of care.
+  files=`find . -path "*rust_icu_${header_basename}/src/*.rs"`
+  impl_fns=""
+  unimpl_fns=""
+  for file in ${files}; do
+    echo $header_basename: $header_fullname ${file}
+    found_fns="$(grep "/// Implements \`" ${file} | sed -e 's/.*`\(.*\)`.*$/\1/' | sed -e 's/\(.*\)()$/\1/' | sort -fs | uniq)"
+    # Match the extracted function to a function in the header being processed
+    # (in case the "/// Implements `" comment is used in another context)
+    for impl_fn in ${found_fns}; do
+      for all_fn in ${all}; do
+        if [ ${impl_fn} = ${all_fn} ]
+        then
+          impl_fns="${impl_fns} ${impl_fn}"
+          break
+        fi
+      done
+    done
+  done
+  # Sort again in case we process multiple source files
+  impl_fns="$(echo ${impl_fns} | sort -fs | uniq)"
+  for impl_fn in ${impl_fns}; do
+    printf "%s\n" ${impl_fn} >> "${TOP_DIR}/coverage/${header_basename}_implemented.txt"
+  done
+  unimpl_fns=""
+  for all_fn in ${all}; do
+    found="false"
+    for impl_fn in ${impl_fns}; do
+      if [ ${impl_fn} = ${all_fn} ]
+      then
+        found="true"
+        break
+      fi
+    done
+    if [ "false" = ${found} ]
+    then
+      unimpl_fns="${unimpl_fns} ${all_fn}"
+    fi
+  done
+
+  total_functions=$(echo ${all} | wc -w)
+  implemented_functions=$(echo ${impl_fns} | wc -w)
+  printf "| \`%s.h\` | %s / %s | \n" ${header_basename} ${implemented_functions} ${total_functions} >> "${REPORT_FILE_HEADER}"
+
+  cat <<EOF >>"${REPORT_FILE_DETAIL}"
 
 # Header: \`${header_basename}.h\`
 
 | Unimplemented | Implemented |
 | ------------- | ----------- |
 EOF
-  all=`cat ${TOP_DIR}/coverage/${header_basename}_all.txt | sort -fs`
-  implemented=`cat "${TOP_DIR}/coverage/${header_basename}_implemented.txt" | sort -fs`
-  for fun in ${implemented}; do
-    echo "| | \`${fun}\` |" >>"${REPORT_FILE}"
+  for impl_fn in ${impl_fns}; do
+    printf "| | \`%s\` |\n" ${impl_fn} >>"${REPORT_FILE_DETAIL}"
   done
 
-  unimplemented="$(comm -23 \
-    "${TOP_DIR}/coverage/${header_basename}_all.txt" \
-    "${TOP_DIR}/coverage/${header_basename}_implemented.txt" | sort -fs | uniq)"
-  for fun in ${unimplemented}; do
-    echo "| \`${fun}\` | |" >>"${REPORT_FILE}"
+  for fun in ${unimpl_fns}; do
+    printf "| \`%s\` | |\n"  ${fun} >>"${REPORT_FILE_DETAIL}"
   done
-
-  total_cnt=`echo ${all} | wc -w`
-  implemented_cnt=`echo ${implemented} | wc -w`
-  unimplemented_cnt=`echo ${unimplemented} | wc -w`
-  computed_total_cnt=`expr ${unimplemented_cnt} + ${implemented_cnt}`
-  if [ ${computed_total_cnt} -ne ${total_cnt} ]
-  then
-    printf "Warning: Implemented + Unimplemented != Total\n" >> ${REPORT_FILE}
-    printf "Total: %s Implemented: %s Unimplemented: %s\n" ${total_cnt} ${implemented_cnt} ${unimplemented_cnt} >> "${REPORT_FILE}"
-    for impl_fn in ${implemented}; do
-      found="false"
-      for all_fn in ${all}; do
-        if [ ${impl_fn} = ${all_fn} ]
-        then
-          found="true"
-          break
-        fi
-      done
-      if [ "false" = ${found} ]
-      then
-        printf "Function %s was designated as implemented but not found in the API\n" ${impl_fn} >> "${REPORT_FILE}"
-      fi
-    done
-  fi
 
   sort -fs -o "${TOP_DIR}/coverage/${header_basename}_all.txt" "${TOP_DIR}/coverage/${header_basename}_all.txt"
   sort -fs -o "${TOP_DIR}/coverage/${header_basename}_implemented.txt" "${TOP_DIR}/coverage/${header_basename}_implemented.txt"
 done
+
+cat ${REPORT_FILE_HEADER} ${REPORT_FILE_DETAIL} > ${REPORT_FILE}
+rm ${REPORT_FILE_HEADER}
+rm ${REPORT_FILE_DETAIL}
 

--- a/coverage/report.md
+++ b/coverage/report.md
@@ -5,18 +5,18 @@
 | `ubrk.h` | 19 / 23 | 
 | `ucal.h` | 15 / 47 | 
 | `ucol.h` | 8 / 51 | 
-| `udat.h` | 10 / 38 | 
-| `udata.h` | 4 / 8 | 
-| `uenum.h` | 7 / 8 | 
+| `udat.h` | 5 / 38 | 
+| `udata.h` | 2 / 8 | 
+| `uenum.h` | 3 / 8 | 
 | `uformattable.h` | 6 / 13 | 
 | `ulistformatter.h` | 2 / 8 | 
 | `uloc.h` | 28 / 42 | 
-| `umsg.h` | 6 / 20 | 
+| `umsg.h` | 5 / 20 | 
 | `unum.h` | 14 / 32 | 
-| `unumberformatter.h` | 7 / 6 | 
+| `unumberformatter.h` | 3 / 6 | 
 | `upluralrules.h` | 3 / 8 | 
-| `ustring.h` | 3 / 61 | 
-| `utext.h` | 3 / 28 | 
+| `ustring.h` | 2 / 61 | 
+| `utext.h` | 2 / 28 | 
 | `utrans.h` | 10 / 20 | 
 | `unorm2.h` | 8 / 22 | 
 # Unimplemented functions per header
@@ -162,11 +162,6 @@
 
 | Unimplemented | Implemented |
 | ------------- | ----------- |
-| | `UDateFormat` |
-| | `UDateTimePatternGenerator` |
-| | `udatpg_clone` |
-| | `udatpg_getBestPattern` |
-| | `udatpg_open` |
 | | `udat_close` |
 | | `udat_format` |
 | | `udat_open` |
@@ -205,41 +200,24 @@
 | `udat_toPatternRelativeDate` | |
 | `udat_toPatternRelativeTime` | |
 | `udat_unregisterOpener` | |
-Warning: Implemented + Unimplemented != Total
-Total: 38 Implemented: 10 Unimplemented: 33
-Function UDateFormat was designated as implemented but not found in the API
-Function UDateTimePatternGenerator was designated as implemented but not found in the API
-Function udatpg_clone was designated as implemented but not found in the API
-Function udatpg_getBestPattern was designated as implemented but not found in the API
-Function udatpg_open was designated as implemented but not found in the API
 
 # Header: `udata.h`
 
 | Unimplemented | Implemented |
 | ------------- | ----------- |
-| | `UDataMemory` |
 | | `udata_open` |
 | | `udata_setCommonData` |
-| | `u_setDataDirectory` |
 | `udata_close` | |
 | `udata_getInfo` | |
 | `udata_getMemory` | |
 | `udata_openChoice` | |
 | `udata_setAppData` | |
 | `udata_setFileAccess` | |
-Warning: Implemented + Unimplemented != Total
-Total: 8 Implemented: 4 Unimplemented: 6
-Function UDataMemory was designated as implemented but not found in the API
-Function u_setDataDirectory was designated as implemented but not found in the API
 
 # Header: `uenum.h`
 
 | Unimplemented | Implemented |
 | ------------- | ----------- |
-| | `ucal_openCountryTimeZones` |
-| | `ucal_openTimeZoneIDEnumeration` |
-| | `ucal_openTimeZones` |
-| | `UEnumeration` |
 | | `uenum_close` |
 | | `uenum_next` |
 | | `uenum_openCharStringsEnumeration` |
@@ -248,12 +226,6 @@ Function u_setDataDirectory was designated as implemented but not found in the A
 | `uenum_openUCharStringsEnumeration` | |
 | `uenum_reset` | |
 | `uenum_unext` | |
-Warning: Implemented + Unimplemented != Total
-Total: 8 Implemented: 7 Unimplemented: 5
-Function ucal_openCountryTimeZones was designated as implemented but not found in the API
-Function ucal_openTimeZoneIDEnumeration was designated as implemented but not found in the API
-Function ucal_openTimeZones was designated as implemented but not found in the API
-Function UEnumeration was designated as implemented but not found in the API
 
 # Header: `uformattable.h`
 
@@ -337,7 +309,6 @@ Function UEnumeration was designated as implemented but not found in the API
 
 | Unimplemented | Implemented |
 | ------------- | ----------- |
-| | `UMessageFormat` |
 | | `umsg_clone` |
 | | `umsg_close` |
 | | `umsg_format` |
@@ -358,9 +329,6 @@ Function UEnumeration was designated as implemented but not found in the API
 | `u_vformatMessageWithError` | |
 | `u_vparseMessage` | |
 | `u_vparseMessageWithError` | |
-Warning: Implemented + Unimplemented != Total
-Total: 20 Implemented: 6 Unimplemented: 15
-Function UMessageFormat was designated as implemented but not found in the API
 
 # Header: `unum.h`
 
@@ -406,19 +374,9 @@ Function UMessageFormat was designated as implemented but not found in the API
 | | `unumf_formatDecimal` |
 | | `unumf_openForSkeletonAndLocale` |
 | | `unumf_openForSkeletonAndLocaleWithError` |
-| | `unumf_openResult` |
-| | `unumf_resultGetAllFieldPositions` |
-| | `unumf_resultNextFieldPosition` |
-| | `unumf_resultToString` |
 | `unumf_close` | |
 | `unumf_formatDouble` | |
 | `unumf_formatInt` | |
-Warning: Implemented + Unimplemented != Total
-Total: 6 Implemented: 7 Unimplemented: 3
-Function unumf_openResult was designated as implemented but not found in the API
-Function unumf_resultGetAllFieldPositions was designated as implemented but not found in the API
-Function unumf_resultNextFieldPosition was designated as implemented but not found in the API
-Function unumf_resultToString was designated as implemented but not found in the API
 
 # Header: `upluralrules.h`
 
@@ -437,7 +395,6 @@ Function unumf_resultToString was designated as implemented but not found in the
 
 | Unimplemented | Implemented |
 | ------------- | ----------- |
-| | `UChar*` |
 | | `u_strFromUTF8` |
 | | `u_strToUTF8` |
 | `u_austrcpy` | |
@@ -499,9 +456,6 @@ Function unumf_resultToString was designated as implemented but not found in the
 | `u_uastrncpy` | |
 | `u_unescape` | |
 | `u_unescapeAt` | |
-Warning: Implemented + Unimplemented != Total
-Total: 61 Implemented: 3 Unimplemented: 59
-Function UChar* was designated as implemented but not found in the API
 
 # Header: `utext.h`
 
@@ -509,7 +463,6 @@ Function UChar* was designated as implemented but not found in the API
 | ------------- | ----------- |
 | | `utext_clone` |
 | | `utext_close` |
-| | `utext_open` |
 | `utext_char32At` | |
 | `utext_copy` | |
 | `utext_current32` | |
@@ -536,9 +489,6 @@ Function UChar* was designated as implemented but not found in the API
 | `utext_replace` | |
 | `utext_setNativeIndex` | |
 | `utext_setup` | |
-Warning: Implemented + Unimplemented != Total
-Total: 28 Implemented: 3 Unimplemented: 26
-Function utext_open was designated as implemented but not found in the API
 
 # Header: `utrans.h`
 

--- a/coverage/report.md
+++ b/coverage/report.md
@@ -7,10 +7,10 @@
 | `ucol.h` | 8 / 51 | 
 | `udat.h` | 10 / 38 | 
 | `udata.h` | 4 / 8 | 
-| `uenum.h` | 8 / 8 | 
+| `uenum.h` | 7 / 8 | 
 | `uformattable.h` | 6 / 13 | 
 | `ulistformatter.h` | 2 / 8 | 
-| `uloc.h` | 30 / 42 | 
+| `uloc.h` | 28 / 42 | 
 | `umsg.h` | 6 / 20 | 
 | `unum.h` | 14 / 32 | 
 | `unumberformatter.h` | 7 / 6 | 
@@ -205,6 +205,13 @@
 | `udat_toPatternRelativeDate` | |
 | `udat_toPatternRelativeTime` | |
 | `udat_unregisterOpener` | |
+Warning: Implemented + Unimplemented != Total
+Total: 38 Implemented: 10 Unimplemented: 33
+Function UDateFormat was designated as implemented but not found in the API
+Function UDateTimePatternGenerator was designated as implemented but not found in the API
+Function udatpg_clone was designated as implemented but not found in the API
+Function udatpg_getBestPattern was designated as implemented but not found in the API
+Function udatpg_open was designated as implemented but not found in the API
 
 # Header: `udata.h`
 
@@ -220,6 +227,10 @@
 | `udata_openChoice` | |
 | `udata_setAppData` | |
 | `udata_setFileAccess` | |
+Warning: Implemented + Unimplemented != Total
+Total: 8 Implemented: 4 Unimplemented: 6
+Function UDataMemory was designated as implemented but not found in the API
+Function u_setDataDirectory was designated as implemented but not found in the API
 
 # Header: `uenum.h`
 
@@ -232,12 +243,17 @@
 | | `uenum_close` |
 | | `uenum_next` |
 | | `uenum_openCharStringsEnumeration` |
-| | `uloc_openKeywords` |
 | `uenum_count` | |
 | `uenum_openFromStringEnumeration` | |
 | `uenum_openUCharStringsEnumeration` | |
 | `uenum_reset` | |
 | `uenum_unext` | |
+Warning: Implemented + Unimplemented != Total
+Total: 8 Implemented: 7 Unimplemented: 5
+Function ucal_openCountryTimeZones was designated as implemented but not found in the API
+Function ucal_openTimeZoneIDEnumeration was designated as implemented but not found in the API
+Function ucal_openTimeZones was designated as implemented but not found in the API
+Function UEnumeration was designated as implemented but not found in the API
 
 # Header: `uformattable.h`
 
@@ -274,8 +290,6 @@
 
 | Unimplemented | Implemented |
 | ------------- | ----------- |
-| | `icu::Locale::getUnicodeKeywords()` |
-| | `icu::Locale::getUnicodeKeywordValue()` |
 | | `uloc_acceptLanguage` |
 | | `uloc_addLikelySubtags` |
 | | `uloc_canonicalize` |
@@ -292,13 +306,13 @@
 | | `uloc_getDisplayName` |
 | | `uloc_getDisplayScript` |
 | | `uloc_getDisplayVariant` |
-| | `uloc_getKeywordValue()` |
+| | `uloc_getKeywordValue` |
 | | `uloc_getLanguage` |
 | | `uloc_getName` |
 | | `uloc_getScript` |
 | | `uloc_getVariant` |
 | | `uloc_minimizeSubtags` |
-| | `uloc_openKeywords()` |
+| | `uloc_openKeywords` |
 | | `uloc_setDefault` |
 | | `uloc_toLanguageTag` |
 | | `uloc_toLegacyKey` |
@@ -310,14 +324,12 @@
 | `uloc_getISO3Language` | |
 | `uloc_getISOCountries` | |
 | `uloc_getISOLanguages` | |
-| `uloc_getKeywordValue` | |
 | `uloc_getLCID` | |
 | `uloc_getLineOrientation` | |
 | `uloc_getLocaleForLCID` | |
 | `uloc_getParent` | |
 | `uloc_isRightToLeft` | |
 | `uloc_openAvailableByType` | |
-| `uloc_openKeywords` | |
 | `uloc_setKeywordValue` | |
 | `uloc_toLegacyType` | |
 
@@ -346,6 +358,9 @@
 | `u_vformatMessageWithError` | |
 | `u_vparseMessage` | |
 | `u_vparseMessageWithError` | |
+Warning: Implemented + Unimplemented != Total
+Total: 20 Implemented: 6 Unimplemented: 15
+Function UMessageFormat was designated as implemented but not found in the API
 
 # Header: `unum.h`
 
@@ -398,6 +413,12 @@
 | `unumf_close` | |
 | `unumf_formatDouble` | |
 | `unumf_formatInt` | |
+Warning: Implemented + Unimplemented != Total
+Total: 6 Implemented: 7 Unimplemented: 3
+Function unumf_openResult was designated as implemented but not found in the API
+Function unumf_resultGetAllFieldPositions was designated as implemented but not found in the API
+Function unumf_resultNextFieldPosition was designated as implemented but not found in the API
+Function unumf_resultToString was designated as implemented but not found in the API
 
 # Header: `upluralrules.h`
 
@@ -478,6 +499,9 @@
 | `u_uastrncpy` | |
 | `u_unescape` | |
 | `u_unescapeAt` | |
+Warning: Implemented + Unimplemented != Total
+Total: 61 Implemented: 3 Unimplemented: 59
+Function UChar* was designated as implemented but not found in the API
 
 # Header: `utext.h`
 
@@ -512,6 +536,9 @@
 | `utext_replace` | |
 | `utext_setNativeIndex` | |
 | `utext_setup` | |
+Warning: Implemented + Unimplemented != Total
+Total: 28 Implemented: 3 Unimplemented: 26
+Function utext_open was designated as implemented but not found in the API
 
 # Header: `utrans.h`
 

--- a/coverage/udat_implemented.txt
+++ b/coverage/udat_implemented.txt
@@ -1,8 +1,3 @@
-UDateFormat
-UDateTimePatternGenerator
-udatpg_clone
-udatpg_getBestPattern
-udatpg_open
 udat_close
 udat_format
 udat_open

--- a/coverage/udata_implemented.txt
+++ b/coverage/udata_implemented.txt
@@ -1,4 +1,2 @@
-UDataMemory
 udata_open
 udata_setCommonData
-u_setDataDirectory

--- a/coverage/uenum_implemented.txt
+++ b/coverage/uenum_implemented.txt
@@ -5,4 +5,3 @@ UEnumeration
 uenum_close
 uenum_next
 uenum_openCharStringsEnumeration
-uloc_openKeywords

--- a/coverage/uenum_implemented.txt
+++ b/coverage/uenum_implemented.txt
@@ -1,7 +1,3 @@
-ucal_openCountryTimeZones
-ucal_openTimeZoneIDEnumeration
-ucal_openTimeZones
-UEnumeration
 uenum_close
 uenum_next
 uenum_openCharStringsEnumeration

--- a/coverage/uloc_implemented.txt
+++ b/coverage/uloc_implemented.txt
@@ -1,5 +1,3 @@
-icu::Locale::getUnicodeKeywords()
-icu::Locale::getUnicodeKeywordValue()
 uloc_acceptLanguage
 uloc_addLikelySubtags
 uloc_canonicalize
@@ -16,13 +14,13 @@ uloc_getDisplayLanguage
 uloc_getDisplayName
 uloc_getDisplayScript
 uloc_getDisplayVariant
-uloc_getKeywordValue()
+uloc_getKeywordValue
 uloc_getLanguage
 uloc_getName
 uloc_getScript
 uloc_getVariant
 uloc_minimizeSubtags
-uloc_openKeywords()
+uloc_openKeywords
 uloc_setDefault
 uloc_toLanguageTag
 uloc_toLegacyKey

--- a/coverage/umsg_implemented.txt
+++ b/coverage/umsg_implemented.txt
@@ -1,4 +1,3 @@
-UMessageFormat
 umsg_clone
 umsg_close
 umsg_format

--- a/coverage/unumberformatter_implemented.txt
+++ b/coverage/unumberformatter_implemented.txt
@@ -1,7 +1,3 @@
 unumf_formatDecimal
 unumf_openForSkeletonAndLocale
 unumf_openForSkeletonAndLocaleWithError
-unumf_openResult
-unumf_resultGetAllFieldPositions
-unumf_resultNextFieldPosition
-unumf_resultToString

--- a/coverage/ustring_implemented.txt
+++ b/coverage/ustring_implemented.txt
@@ -1,3 +1,2 @@
-UChar*
 u_strFromUTF8
 u_strToUTF8

--- a/coverage/utext_implemented.txt
+++ b/coverage/utext_implemented.txt
@@ -1,3 +1,2 @@
 utext_clone
 utext_close
-utext_open

--- a/rust_icu_uenum/src/lib.rs
+++ b/rust_icu_uenum/src/lib.rs
@@ -224,9 +224,8 @@ pub fn open_time_zones() -> Result<Enumeration, common::Error> {
 }
 
 #[doc(hidden)]
-/// Implements `uloc_openKeywords`.
-// This should be in the `uloc` crate, but this is not possible because of the raw enum
-// initialization. Tested in `uloc`.
+// This has been moved to the `uloc` crate
+#[deprecated(since="4.2.4", note="please use `ULoc::open_keywords` instead")]
 pub fn uloc_open_keywords(locale: &str) -> Result<Enumeration, common::Error> {
     let mut status = common::Error::OK_CODE;
     let asciiz_locale = ffi::CString::new(locale)?;
@@ -276,5 +275,22 @@ mod tests {
         let invalid_utf8 = unsafe { str::from_utf8_unchecked(&destroyed_sparkle_heart) };
         let e = Enumeration::try_from(&vec!["hello", "world", "💖", invalid_utf8][..]);
         assert!(e.is_err(), "was: {:?}", e);
+    }
+
+    #[test]
+    fn test_uloc_open_keywords() -> Result<(), common::Error> {
+        let loc = "az-Cyrl-AZ-u-ca-hebrew-fw-sunday-nu-deva-tz-usnyc";
+        #[allow(deprecated)]
+        let keywords: Vec<String> = uloc_open_keywords(loc).unwrap().map(|result| result.unwrap()).collect();
+        assert_eq!(
+            keywords,
+            vec![
+                "calendar".to_string(),
+                "fw".to_string(),
+                "numbers".to_string(),
+                "timezone".to_string()
+            ]
+        );
+        Ok(())
     }
 }

--- a/rust_icu_uloc/src/lib.rs
+++ b/rust_icu_uloc/src/lib.rs
@@ -439,7 +439,7 @@ impl ULoc {
             .map(|result| result.unwrap())
     }
 
-    /// Implementation of `icu::Locale::getUnicodeKeywords()` from the C++ API.
+    /// Implements `icu::Locale::getUnicodeKeywords()` from the C++ API.
     pub fn unicode_keywords(&self) -> impl Iterator<Item = String> {
         self.keywords().filter_map(|s| to_unicode_locale_key(&s))
     }
@@ -463,7 +463,7 @@ impl ULoc {
         .map(|value| if value.is_empty() { None } else { Some(value) })
     }
 
-    /// Implementation of `icu::Locale::getUnicodeKeywordValue()` from the C++ API.
+    /// Implements `icu::Locale::getUnicodeKeywordValue()` from the C++ API.
     pub fn unicode_keyword_value(
         &self,
         unicode_keyword: &str,


### PR DESCRIPTION

- Ignore trailing '()' characters in function names when reporting coverage.
- Only track functions that match a function in the header file of interest as implemented.
- Mark the uenum::uloc_open_keywords as deprecated, copy the implementation into the uloc crate and copy the test that was in the     uloc crate into the uenum crate so that it is still protected by a test even though deprecated.