### PR TITLE
fix: adds a test runner for buildenv

### DIFF
--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -1,5 +1,5 @@
 # rust_icu_buildenv.
-FROM rust:1.71.0 AS buildenv
+FROM rust:1.75.0 AS buildenv
 
 RUN mkdir -p /src
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -93,3 +93,6 @@ latest.stamp: push-buildenv.stamp v74.stamp
 v%.stamp: push-maint-%.stamp push-testenv-%.stamp
 	touch $@
 
+test: tag-maint-74.stamp tag-testenv-74.stamp
+.PHONY: test
+


### PR DESCRIPTION
I remembered that buildenv often bitrots. It might be a good idea to give it a quick check once in a while.