### PR TITLE
rust_icu_sys: fix build with clang-19

### DIFF
--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -22,7 +22,7 @@ paste = "1.0"
 
 [build-dependencies]
 anyhow = "1.0.72"
-bindgen = { version = "0.59.2", optional = true }
+bindgen = { version = "0.69.5", optional = true }
 lazy_static = "1.4"
 
 [lib]


### PR DESCRIPTION
Building in a Fedora 41 container againts clang-19 results in a lib.rs (output from bindgen) that is missing key functions like u_strFromUTF8.

Digging deeper, this is a problem with bindgen, see <https://github.com/rust-lang/rust-bindgen/issues/2945>.

Update bindgen to a newer version which is just new enough to fix the problem.

Fixes <https://github.com/google/rust_icu/issues/305>.