### PR TITLE
feat: create a container for building ICU against main

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,8 +1,1 @@
-# These flags are the only way to tell cargo to add directories to the library
-# search path.  When `build.rs` script is used, this is not needed since the
-# script will set the library paths correctly.  But when it isn't used,
-# something still needs to produce these flags.  With cargo, this is the only
-# way.
-[build]
-rustflags=["-L", "/usr/local/lib"]
-rustdocflags=["-L", "/usr/local/lib"]
+config.toml

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+# These flags are the only way to tell cargo to add directories to the library
+# search path.  When `build.rs` script is used, this is not needed since the
+# script will set the library paths correctly.  But when it isn't used,
+# something still needs to produce these flags.  With cargo, this is the only
+# way.
+[build]
+rustflags=["-L", "/usr/local/lib"]
+rustdocflags=["-L", "/usr/local/lib"]

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,20 @@
+name: Main
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: "43 17 * * 0"
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-default-features:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Test ICU `main`'
+        run: 'make DOCKER_TEST_ENV=rust_icu_testenv-current docker-test-current'
+

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,23 @@ docker-test:
 			${DOCKER_REPO}/${DOCKER_TEST_ENV}:${USED_BUILDENV_VERSION}
 .PHONY: docker-test
 
+# Compiles and tests rust_icu code with the current head at ICU
+docker-test-current:
+	make -C build tag-current.stamp
+	mkdir -p ${CARGO_TARGET_DIR}
+	echo top_dir: ${TOP_DIR}
+	echo pwd: $(shell pwd)
+	docker run ${TTY} \
+			--user=${UID}:${GID} \
+			--volume=${TOP_DIR}:/src/rust_icu \
+			--volume=${CARGO_TARGET_DIR}:/build/cargo \
+			--volume=${LOGNAME_HOME}/.cargo:/usr/local/cargo \
+			--env="CARGO_TEST_ARGS=${DOCKER_TEST_CARGO_TEST_ARGS}" \
+			--env="RUST_ICU_MAJOR_VERSION_NUMBER=${RUST_ICU_MAJOR_VERSION_NUMBER}"\
+			--env="RUST_BACKTRACE=full" \
+			${DOCKER_REPO}/rust_icu_testenv-current:${USED_BUILDENV_VERSION}
+.PHONY: docker-test-current
+
 # Test with the homebrew version of icu4c on macOS with static linking (the default way of linking for distribution on Apple platforms)
 macos-test:
 	brew install icu4c

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 #   make USED_BUILDENV_VERSION=whatever-you-want docker-test
 #
 # NOTE: This version number is completely independent of the crate version.
-USED_BUILDENV_VERSION ?= 1.74.0
+USED_BUILDENV_VERSION ?= 1.82.0
 
 CARGO_FEATURE_VERSION :=
 

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -1,5 +1,8 @@
 # rust_icu_buildenv.
-FROM rust:1.75.0 AS buildenv
+ARG RUST_VERSION=1.82.0
+FROM rust:$RUST_VERSION AS buildenv
+
+ARG BINDGEN_CLI_VERSION=0.69.5
 
 RUN mkdir -p /src
 
@@ -18,7 +21,9 @@ gawk \
 git \
 libclang-dev \
 llvm-dev \
+sed \
 strace \
+sudo \
 ""
 
 RUN \
@@ -26,7 +31,7 @@ cargo version && \
 rustup component add rustfmt
 
 RUN \
-cargo install --force --version 0.66.1 bindgen-cli
+cargo install --force --version $BINDGEN_CLI_VERSION bindgen-cli
 
 RUN chmod --recursive a+rwx $HOME
 RUN echo $HOME && cd && ls -ld $HOME

--- a/build/Dockerfile.maint
+++ b/build/Dockerfile.maint
@@ -12,9 +12,10 @@ ARG ICU_VERSION_TAG
 # Install ICU from source.
 ENV ICU_SOURCE_DIR="/src/icu"
 RUN echo "$ICU_VERSION_TAG"
-RUN git clone https://github.com/unicode-org/icu.git && \
+RUN git clone --depth=1 -b $ICU_VERSION_TAG \
+        https://github.com/unicode-org/icu.git && \
     cd $ICU_SOURCE_DIR && \
-		git fetch origin $ICU_VERSION_TAG && \
+		git fetch --depth=1 origin $ICU_VERSION_TAG && \
 		git checkout $ICU_VERSION_TAG
 
 ENV ICU4C_BUILD_DIR=/build/icu4c-build
@@ -23,7 +24,7 @@ RUN mkdir -p $ICU4C_BUILD_DIR && \
 		env CXXFLAGS="-ggdb -DU_DEBUG=1" \
 		    $ICU_SOURCE_DIR/icu4c/source/runConfigureICU Linux \
 			  --enable-static \
-			  --prefix=/usr/local \
+			  --prefix="/usr/local" \
 			  --enable-debug && \
 		make -j && \
 		make install && \

--- a/build/Dockerfile.testenv.current
+++ b/build/Dockerfile.testenv.current
@@ -3,11 +3,14 @@
 ARG DOCKER_REPO=filipfilmar
 ARG VERSION=0.0.0
 ARG ICU_VERSION_TAG=maint-72
-FROM $DOCKER_REPO/rust_icu_$ICU_VERSION_TAG:$VERSION AS buildenv
+FROM $DOCKER_REPO/rust_icu_buildenv:$VERSION AS buildenv
 ARG DOCKER_REPO
 ARG VERSION
 ARG ICU_VERSION_TAG
 ARG BINDGEN_CLI_VERSION=0.69.5
+
+ENV CARGO_BUILD_DIR=/build/cargo
+RUN mkdir -p $CARGO_BUILD_DIR
 
 # Mount the rust_icu source top level directory here.
 ENV RUST_ICU_SOURCE_DIR=/src/rust_icu
@@ -19,12 +22,12 @@ RUN mkdir -p $RUST_ICU_SOURCE_DIR && \
 		  /build \
 		  /usr/local/cargo
 
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod a+rwx /entrypoint.sh
+COPY entrypoint-test-current.sh /entrypoint-test-current.sh
+RUN chmod a+rwx /entrypoint-test-current.sh
 
 RUN cargo install --force --version $BINDGEN_CLI_VERSION bindgen-cli
 
 ENV CARGO_TEST_ARGS=""
 ENV RUST_ICU_MAJOR_VERSION_NUMBER=""
-ENTRYPOINT /entrypoint.sh
+ENTRYPOINT /entrypoint-test-current.sh
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -28,6 +28,7 @@ all: \
 	v71.stamp \
 	v63.stamp \
 	push-testenv.stamp \
+	push-current.stamp \
 	push-hermetic.stamp
 	echo "buildenv-version: ${VERSION}"
 .PHONY: all
@@ -55,7 +56,26 @@ build-maint-%.stamp: Dockerfile.maint Dockerfile.buildenv
 			-f $< -t rust_icu_maint-$*:${VERSION} .
 	touch $@
 
-build-testenv-%.stamp: Dockerfile.testenv Dockerfile.buildenv entrypoint.sh
+push-current.stamp: tag-current.stamp
+	docker push ${DOCKER_REPO}/rust_icu_testenv-current:${VERSION}
+	touch $@
+
+tag-current.stamp: Makefile build-current.stamp
+	docker tag rust_icu_testenv-current:${VERSION} ${DOCKER_REPO}/rust_icu_testenv-current:${VERSION}
+	touch $@
+
+build-current.stamp: Dockerfile.testenv.current \
+	Dockerfile.buildenv Makefile \
+	entrypoint.sh entrypoint-test-current.sh
+	docker build \
+			--build-arg DOCKER_REPO=${DOCKER_REPO} \
+			--build-arg VERSION=${VERSION} \
+			--build-arg ICU_VERSION_TAG=maint-74 \
+			-f $< -t rust_icu_testenv-current:${VERSION} .
+	touch $@
+
+build-testenv-%.stamp: Dockerfile.testenv Dockerfile.buildenv \
+	entrypoint.sh entrypoint-test-current.sh
 	docker build \
 			--build-arg DOCKER_REPO=${DOCKER_REPO} \
 			--build-arg VERSION=${VERSION} \
@@ -87,12 +107,18 @@ latest.stamp: push-buildenv.stamp v74.stamp
 	push-maint-71.stamp push-testenv-71.stamp \
 	build-testenv-71.stamp tag-testenv-71.stamp \
 	push-maint-63.stamp push-testenv-63.stamp \
-	build-testenv-63.stamp tag-testenv-63.stamp
+	build-testenv-63.stamp tag-testenv-63.stamp \
+	build-current.stamp push-current.stamp
 
 
 v%.stamp: push-maint-%.stamp push-testenv-%.stamp
 	touch $@
 
-test: tag-maint-74.stamp tag-testenv-74.stamp
+# Use `make test` to test building various environments with local
+# changes, and an unofficial tag.  This target should not push.
+test: Makefile \
+	build-buildenv.stamp tag-buildenv.stamp \
+	build-maint-74.stamp tag-maint-74.stamp \
+	build-current.stamp tag-current.stamp
 .PHONY: test
 

--- a/build/README.md
+++ b/build/README.md
@@ -30,9 +30,29 @@ cd build
 make DOCKER_REPO=yourrepo all
 ```
 
-Omitting `DOCKER_REPO` will cause the push to happen to the default repository, 
+Omitting `DOCKER_REPO` will cause the push to happen to the default repository,
 which you may not be allowed to write to.
 
 # Building the images locally
 
-It is possible to build the images locally with `docker`
+It is possible to build the images locally with `docker`.
+
+From the top level directory:
+
+```
+make -C build test
+```
+
+This will build and tag docker images locally.  Note the resulting image
+tag: `filipfilmar/rust_icu_testenv-74:1.4.2-120-g6ac9feb-dirty`
+
+## Using the built image
+
+You can now use the suffix of that tag, the bits after `:` to run
+a local docker target like so:
+
+```
+make docker-test-current \
+     USED_BUILDENV_VERSION=1.4.2-120-g6ac9feb-dirty
+```
+

--- a/build/entrypoint-test-current.sh
+++ b/build/entrypoint-test-current.sh
@@ -1,0 +1,65 @@
+#! /bin/bash
+set -eo pipefail
+set -x
+
+echo "${0}"
+
+ICU_LIBRARY_PATH="${ICU_LIBRARY_PATH:-/build/icu-install}"
+
+# Needed to take icu-config from ICU_LIBRARY_PATH, not the default
+# /usr/local/bin.
+PATH="${ICU_LIBRARY_PATH}/bin:${PATH}"
+export PATH
+
+readonly _local_cargo_options="\
+    --target-dir=/build/cargo \
+    "
+
+cd $RUST_ICU_SOURCE_DIR
+ls -d .
+readonly __all_dirs="$(ls -d rust_icu_*)"
+
+env
+
+function run_cargo_test() {
+  env LD_LIBRARY_PATH="${ICU_LIBRARY_PATH}/lib" \
+      PKG_CONFIG_LIBDIR="${ICU_LIBRARY_PATH}/lib/pkgconfig" \
+      cargo test \
+          ${_local_cargo_options} \
+            ${CARGO_TEST_ARGS}
+}
+
+function run_cargo_doc() {
+  env LD_LIBRARY_PATH="${ICU_LIBRARY_PATH}/lib" \
+      PKG_CONFIG_LIBDIR="${ICU_LIBRARY_PATH}/lib/pkgconfig" \
+      cargo doc ${_local_cargo_options} ${CARGO_TEST_ARGS}
+}
+
+(
+    echo "Checking out, building and installing the latest ICU"
+    mkdir -p /build
+    cd /build
+    git clone --depth=1 https://github.com/unicode-org/icu.git
+    mkdir -p /build/icu4c-build
+    mkdir -p ${ICU_LIBRARY_PATH}
+    cd /build/icu4c-build
+    env CXXFLAGS="-ggdb -DU_DEBUG=1" \
+        /build/icu/icu4c/source/runConfigureICU Linux \
+            --enable-static \
+            --prefix="${ICU_LIBRARY_PATH}" \
+            --enable-debug && \
+        make -j && \
+        make install && \
+        icu-config --version
+)
+
+ls -lR $ICU_LIBRARY_PATH/lib
+
+echo "Testing rust_icu crates"
+for directory in ${__all_dirs}; do
+  (
+    cd "${directory}"
+    run_cargo_test
+    run_cargo_doc
+  )
+done


### PR DESCRIPTION
For the longest time, we had no way to run tests of rust_icu
against top-of-tree ICU. This meant that if a build break was
in the works upstream, we would not know until the release.

This change fixes the issue. We now maintain a "current" environment
which will download and build ICU from `main` before running tests.

Also a small fix: 

- fix: the config file extension is not required to be .toml