### PR TITLE
chore: release a new buildenv, and a new workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,14 @@ jobs:
         run: make macos-test
       - if: matrix.runs-on == 'ubuntu-latest'
         run: make test
+  test-main-branch:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        icu_version: [74]
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Test ICU `main`'
+        run: |
+          make DOCKER_TEST_ENV=rust_icu_testenv-current RUST_ICU_MAJOR_VERSION_NUMBER=${{matrix.icu_version}} docker-test-current
+

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ docker-test:
 
 # Compiles and tests rust_icu code with the current head at ICU
 docker-test-current:
-	make -C build tag-current.stamp
 	mkdir -p ${CARGO_TARGET_DIR}
 	echo top_dir: ${TOP_DIR}
 	echo pwd: $(shell pwd)


### PR DESCRIPTION
This starts using the new "build rust_icu with `main` ICU branch" test workflow.and carefully at that

It does take a long time to complete, some 10 minutes. It builds ICU from `main` sequentially due to hitting memory issues otherwise. But the build seems to complete with success, and this is what we wanted.