### PR TITLE
fix: run bindgen natively on macOS instead of using Linux-generated bindings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        # TODO: #301: re-enable.
-        # runs-on: [ubuntu-latest, macos-latest]
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - if: matrix.runs-on == 'macos-latest'

--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,26 @@ docker-test-current:
 			${DOCKER_REPO}/rust_icu_testenv-current:${USED_BUILDENV_VERSION}
 .PHONY: docker-test-current
 
-# Test with the homebrew version of icu4c on macOS with static linking (the default way of linking for distribution on Apple platforms)
+# Test with the homebrew version of icu4c on macOS, running bindgen natively
+# using the ICU headers provided by Homebrew and the clang toolchain from Xcode.
+# Two passes: dynamic linking (default) and static linking.
+#
+# brew --prefix icu4c resolves the keg-only formula prefix.  On some
+# environments (e.g. GitHub Actions) the unversioned alias is not recognised
+# and brew --prefix returns a non-zero exit; in that case we fall back to
+# querying brew list for the actual installed formula name (e.g. icu4c@78).
 macos-test:
 	brew install icu4c
-	RUST_ICU_LINK_SEARCH_DIR="$(shell brew --prefix)/opt/icu4c/lib" \
-	RUST_ICU_MAJOR_VERSION_NUMBER=${RUST_ICU_MAJOR_VERSION_NUMBER} \
-	cargo test --no-default-features --features=icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_version_in_env,renaming,static
+	ICU_PREFIX=$$(brew --prefix icu4c 2>/dev/null \
+	    || brew --prefix $$(brew list --formula | grep -m1 '^icu4c')) \
+	    && PATH="$$ICU_PREFIX/bin:$$PATH" \
+	       PKG_CONFIG_PATH="$$ICU_PREFIX/lib/pkgconfig:$$PKG_CONFIG_PATH" \
+	       RUSTFLAGS="-L $$ICU_PREFIX/lib" \
+	       cargo test --no-default-features --features=use-bindgen,icu_config,renaming,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus \
+	    && PATH="$$ICU_PREFIX/bin:$$PATH" \
+	       PKG_CONFIG_PATH="$$ICU_PREFIX/lib/pkgconfig:$$PKG_CONFIG_PATH" \
+	       RUSTFLAGS="-L $$ICU_PREFIX/lib" \
+	       cargo test --no-default-features --features=use-bindgen,icu_config,renaming,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,static
 .PHONY: macos-test
 
 # Refreshes the static bindgen output (contents of ./rust_icu_sys/bindgen) based

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -404,7 +404,14 @@ macro_rules! versioned_function {
 
         let lib_dir = ICUConfig::new().libdir()?;
         println!("cargo:rustc-link-search=native={}", lib_dir);
-        println!("cargo:rustc-flags={}", ICUConfig::new().ldflags()?);
+        // When static linking is requested, rustc_link_libs() emits the
+        // individual cargo:rustc-link-lib=static=... directives.  Emitting
+        // cargo:rustc-flags with the dynamic -l flags from icu-config at the
+        // same time causes rustc to reject the conflicting link modifiers, so
+        // skip it here and let rustc_link_libs() handle everything.
+        if env::var_os("CARGO_FEATURE_STATIC").is_none() {
+            println!("cargo:rustc-flags={}", ICUConfig::new().ldflags()?);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Switches `macos-test` from `icu_version_in_env` (pre-built Linux bindings) to native bindgen via `use-bindgen,icu_config,renaming`, eliminating a dependency on Linux-generated artifacts that embedded Linux-specific type definitions
- Adds a second `macos-test` pass with the `static` feature to exercise static linking on macOS; fixes a `build.rs` conflict that previously made `use-bindgen+icu_config+static` fail with "overriding linking modifiers" — `icu_config_autodetect()` was emitting `cargo:rustc-flags` with dynamic `-l` flags at the same time as the `static` feature's `cargo:rustc-link-lib=static` directives
- Re-enables `macos-latest` in the `test-static-linking` CI job (Closes #301)
- Fixes `rust_icu_utext::test::partial_eq` to use a shallow clone instead of a deep clone: `utext_equals` compares the `context` pointer, which differs after a deep clone (new storage allocated); this test was never run on macOS before because the CI job was disabled
- Adds `rust_icu_utext::test::try_clone_combinations` covering all four `(deep, readonly)` combinations with commentary explaining the ICU source behavior and the uncertainty around whether the original deep-clone assertion was silently failing on Linux

## Test plan

- [x] `make macos-test` passes locally (dynamic and static passes, 2 tests in `rust_icu_utext`)
- [ ] `test-static-linking` CI job passes on both `ubuntu-latest` and `macos-latest`
- [ ] Existing Docker-based CI jobs (`test-default-features`, `test-with-features`) unaffected

This commit was created by an automated coding assistant, with human supervision.