### PR TITLE
fix: block also __gnuc_va_list to build on mingw target

### DIFF
--- a/rust_icu_sys/bindgen/run_bindgen.sh
+++ b/rust_icu_sys/bindgen/run_bindgen.sh
@@ -165,6 +165,7 @@ readonly BINDGEN_BLOCKLIST_FUNCTIONS=(
 readonly BINDGEN_BLOCKLIST_TYPES=(
         "va_list"
         "__builtin_va_list"
+        "__gnuc_va_list"
 )
 
 _bindgen="bindgen"

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -114,6 +114,7 @@ mod inner {
         static ref BINDGEN_BLOCKLIST_TYPES: Vec<&'static str> = vec![
             "va_list",
             "__builtin_va_list",
+            "__gnuc_va_list",
         ];
 
         // C types that will be made available to rust code.  Add more to this list if you want to


### PR DESCRIPTION
relevant commit: https://github.com/google/rust_icu/commit/c4d1fd5696359e1139e8009dedd774207ffb9f65
relevant ci log:

```
error[E0425]: cannot find type `__builtin_va_list` in this scope
 --> D:\a\ewt-rs\ewt-rs\target\x86_64-pc-windows-gnullvm\release\build\rust_icu_sys-dafe17c0363b1938\out/lib.rs:3:27
  |
3 | pub type __gnuc_va_list = __builtin_va_list;
  |                           ^^^^^^^^^^^^^^^^^ not found in this scope
```
https://github.com/Master-Hash/ewt-rs/actions/runs/24435036798/job/71387372661?pr=47