### PR TITLE
chore(rust_icu_sys): regenerate static bindgen files

### DIFF
--- a/rust_icu_sys/bindgen/lib_63.rs
+++ b/rust_icu_sys/bindgen/lib_63.rs
@@ -4507,7 +4507,6 @@ unsafe extern "C" {
         status: *mut UErrorCode,
     ) -> i32;
 }
-pub type va_list = __builtin_va_list;
 unsafe extern "C" {
     pub fn u_formatMessage_63(
         locale: *const ::std::os::raw::c_char,
@@ -4520,17 +4519,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessage_63(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessage_63(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4539,17 +4527,6 @@ unsafe extern "C" {
         sourceLength: i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessage_63(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -4565,18 +4542,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessageWithError_63(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        parseError: *mut UParseError,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessageWithError_63(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4586,18 +4551,6 @@ unsafe extern "C" {
         parseError: *mut UParseError,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessageWithError_63(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        parseError: *mut UParseError,
-        status: *mut UErrorCode,
     );
 }
 pub type UMessageFormat = *mut ::std::os::raw::c_void;
@@ -4649,15 +4602,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn umsg_vformat_63(
-        fmt: *const UMessageFormat,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn umsg_parse_63(
         fmt: *const UMessageFormat,
         source: *const UChar,
@@ -4665,16 +4609,6 @@ unsafe extern "C" {
         count: *mut i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn umsg_vparse_63(
-        fmt: *const UMessageFormat,
-        source: *const UChar,
-        sourceLength: i32,
-        count: *mut i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -4810,6 +4744,233 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn uplrules_getKeywords_63(
         uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UResourceBundle {
+    _unused: [u8; 0],
+}
+impl UResType {
+    pub const RES_NONE: UResType = UResType::URES_NONE;
+}
+impl UResType {
+    pub const RES_STRING: UResType = UResType::URES_STRING;
+}
+impl UResType {
+    pub const RES_BINARY: UResType = UResType::URES_BINARY;
+}
+impl UResType {
+    pub const RES_TABLE: UResType = UResType::URES_TABLE;
+}
+impl UResType {
+    pub const RES_ALIAS: UResType = UResType::URES_ALIAS;
+}
+impl UResType {
+    pub const RES_INT: UResType = UResType::URES_INT;
+}
+impl UResType {
+    pub const RES_ARRAY: UResType = UResType::URES_ARRAY;
+}
+impl UResType {
+    pub const RES_INT_VECTOR: UResType = UResType::URES_INT_VECTOR;
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq, Eq)]
+pub enum UResType {
+    URES_NONE = -1,
+    URES_STRING = 0,
+    URES_BINARY = 1,
+    URES_TABLE = 2,
+    URES_ALIAS = 3,
+    URES_INT = 7,
+    URES_ARRAY = 8,
+    URES_INT_VECTOR = 14,
+    RES_RESERVED = 15,
+    URES_LIMIT = 16,
+}
+unsafe extern "C" {
+    pub fn ures_open_63(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openDirect_63(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openU_63(
+        packageName: *const UChar,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_countArrayItems_63(
+        resourceBundle: *const UResourceBundle,
+        resourceKey: *const ::std::os::raw::c_char,
+        err: *mut UErrorCode,
+    ) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_close_63(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_getVersionNumber_63(
+        resourceBundle: *const UResourceBundle,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getVersion_63(resB: *const UResourceBundle, versionInfo: *mut u8);
+}
+unsafe extern "C" {
+    pub fn ures_getLocale_63(
+        resourceBundle: *const UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getLocaleByType_63(
+        resourceBundle: *const UResourceBundle,
+        type_: ULocDataLocaleType,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openFillIn_63(
+        r: *mut UResourceBundle,
+        packageName: *const ::std::os::raw::c_char,
+        localeID: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    );
+}
+unsafe extern "C" {
+    pub fn ures_getString_63(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8String_63(
+        resB: *const UResourceBundle,
+        dest: *mut ::std::os::raw::c_char,
+        length: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getBinary_63(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const u8;
+}
+unsafe extern "C" {
+    pub fn ures_getIntVector_63(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const i32;
+}
+unsafe extern "C" {
+    pub fn ures_getUInt_63(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> u32;
+}
+unsafe extern "C" {
+    pub fn ures_getInt_63(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getSize_63(resourceBundle: *const UResourceBundle) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getType_63(resourceBundle: *const UResourceBundle) -> UResType;
+}
+unsafe extern "C" {
+    pub fn ures_getKey_63(resourceBundle: *const UResourceBundle) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_resetIterator_63(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_hasNext_63(resourceBundle: *const UResourceBundle) -> UBool;
+}
+unsafe extern "C" {
+    pub fn ures_getNextResource_63(
+        resourceBundle: *mut UResourceBundle,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getNextString_63(
+        resourceBundle: *mut UResourceBundle,
+        len: *mut i32,
+        key: *mut *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getByIndex_63(
+        resourceBundle: *const UResourceBundle,
+        indexR: i32,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByIndex_63(
+        resourceBundle: *const UResourceBundle,
+        indexS: i32,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByIndex_63(
+        resB: *const UResourceBundle,
+        stringIndex: i32,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getByKey_63(
+        resourceBundle: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByKey_63(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByKey_63(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openAvailableLocales_63(
+        packageName: *const ::std::os::raw::c_char,
         status: *mut UErrorCode,
     ) -> *mut UEnumeration;
 }
@@ -5626,7 +5787,6 @@ unsafe extern "C" {
         pErrorCode: *mut UErrorCode,
     ) -> *mut UCPTrie;
 }
-pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq)]
 pub struct __va_list_tag {

--- a/rust_icu_sys/bindgen/lib_71.rs
+++ b/rust_icu_sys/bindgen/lib_71.rs
@@ -4671,7 +4671,6 @@ unsafe extern "C" {
         status: *mut UErrorCode,
     );
 }
-pub type va_list = __builtin_va_list;
 unsafe extern "C" {
     pub fn u_formatMessage_71(
         locale: *const ::std::os::raw::c_char,
@@ -4684,17 +4683,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessage_71(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessage_71(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4703,17 +4691,6 @@ unsafe extern "C" {
         sourceLength: i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessage_71(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -4729,18 +4706,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessageWithError_71(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        parseError: *mut UParseError,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessageWithError_71(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4750,18 +4715,6 @@ unsafe extern "C" {
         parseError: *mut UParseError,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessageWithError_71(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        parseError: *mut UParseError,
-        status: *mut UErrorCode,
     );
 }
 pub type UMessageFormat = *mut ::std::os::raw::c_void;
@@ -4813,15 +4766,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn umsg_vformat_71(
-        fmt: *const UMessageFormat,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn umsg_parse_71(
         fmt: *const UMessageFormat,
         source: *const UChar,
@@ -4829,16 +4773,6 @@ unsafe extern "C" {
         count: *mut i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn umsg_vparse_71(
-        fmt: *const UMessageFormat,
-        source: *const UChar,
-        sourceLength: i32,
-        count: *mut i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -5020,6 +4954,233 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn uplrules_getKeywords_71(
         uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UResourceBundle {
+    _unused: [u8; 0],
+}
+impl UResType {
+    pub const RES_NONE: UResType = UResType::URES_NONE;
+}
+impl UResType {
+    pub const RES_STRING: UResType = UResType::URES_STRING;
+}
+impl UResType {
+    pub const RES_BINARY: UResType = UResType::URES_BINARY;
+}
+impl UResType {
+    pub const RES_TABLE: UResType = UResType::URES_TABLE;
+}
+impl UResType {
+    pub const RES_ALIAS: UResType = UResType::URES_ALIAS;
+}
+impl UResType {
+    pub const RES_INT: UResType = UResType::URES_INT;
+}
+impl UResType {
+    pub const RES_ARRAY: UResType = UResType::URES_ARRAY;
+}
+impl UResType {
+    pub const RES_INT_VECTOR: UResType = UResType::URES_INT_VECTOR;
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq, Eq)]
+pub enum UResType {
+    URES_NONE = -1,
+    URES_STRING = 0,
+    URES_BINARY = 1,
+    URES_TABLE = 2,
+    URES_ALIAS = 3,
+    URES_INT = 7,
+    URES_ARRAY = 8,
+    URES_INT_VECTOR = 14,
+    RES_RESERVED = 15,
+    URES_LIMIT = 16,
+}
+unsafe extern "C" {
+    pub fn ures_open_71(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openDirect_71(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openU_71(
+        packageName: *const UChar,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_countArrayItems_71(
+        resourceBundle: *const UResourceBundle,
+        resourceKey: *const ::std::os::raw::c_char,
+        err: *mut UErrorCode,
+    ) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_close_71(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_getVersionNumber_71(
+        resourceBundle: *const UResourceBundle,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getVersion_71(resB: *const UResourceBundle, versionInfo: *mut u8);
+}
+unsafe extern "C" {
+    pub fn ures_getLocale_71(
+        resourceBundle: *const UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getLocaleByType_71(
+        resourceBundle: *const UResourceBundle,
+        type_: ULocDataLocaleType,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openFillIn_71(
+        r: *mut UResourceBundle,
+        packageName: *const ::std::os::raw::c_char,
+        localeID: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    );
+}
+unsafe extern "C" {
+    pub fn ures_getString_71(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8String_71(
+        resB: *const UResourceBundle,
+        dest: *mut ::std::os::raw::c_char,
+        length: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getBinary_71(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const u8;
+}
+unsafe extern "C" {
+    pub fn ures_getIntVector_71(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const i32;
+}
+unsafe extern "C" {
+    pub fn ures_getUInt_71(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> u32;
+}
+unsafe extern "C" {
+    pub fn ures_getInt_71(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getSize_71(resourceBundle: *const UResourceBundle) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getType_71(resourceBundle: *const UResourceBundle) -> UResType;
+}
+unsafe extern "C" {
+    pub fn ures_getKey_71(resourceBundle: *const UResourceBundle) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_resetIterator_71(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_hasNext_71(resourceBundle: *const UResourceBundle) -> UBool;
+}
+unsafe extern "C" {
+    pub fn ures_getNextResource_71(
+        resourceBundle: *mut UResourceBundle,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getNextString_71(
+        resourceBundle: *mut UResourceBundle,
+        len: *mut i32,
+        key: *mut *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getByIndex_71(
+        resourceBundle: *const UResourceBundle,
+        indexR: i32,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByIndex_71(
+        resourceBundle: *const UResourceBundle,
+        indexS: i32,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByIndex_71(
+        resB: *const UResourceBundle,
+        stringIndex: i32,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getByKey_71(
+        resourceBundle: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByKey_71(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByKey_71(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openAvailableLocales_71(
+        packageName: *const ::std::os::raw::c_char,
         status: *mut UErrorCode,
     ) -> *mut UEnumeration;
 }
@@ -5836,7 +5997,6 @@ unsafe extern "C" {
         pErrorCode: *mut UErrorCode,
     ) -> *mut UCPTrie;
 }
-pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq)]
 pub struct __va_list_tag {

--- a/rust_icu_sys/bindgen/lib_72.rs
+++ b/rust_icu_sys/bindgen/lib_72.rs
@@ -4674,7 +4674,6 @@ unsafe extern "C" {
         status: *mut UErrorCode,
     );
 }
-pub type va_list = __builtin_va_list;
 unsafe extern "C" {
     pub fn u_formatMessage_72(
         locale: *const ::std::os::raw::c_char,
@@ -4687,17 +4686,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessage_72(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessage_72(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4706,17 +4694,6 @@ unsafe extern "C" {
         sourceLength: i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessage_72(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -4732,18 +4709,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessageWithError_72(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        parseError: *mut UParseError,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessageWithError_72(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4753,18 +4718,6 @@ unsafe extern "C" {
         parseError: *mut UParseError,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessageWithError_72(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        parseError: *mut UParseError,
-        status: *mut UErrorCode,
     );
 }
 pub type UMessageFormat = *mut ::std::os::raw::c_void;
@@ -4816,15 +4769,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn umsg_vformat_72(
-        fmt: *const UMessageFormat,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn umsg_parse_72(
         fmt: *const UMessageFormat,
         source: *const UChar,
@@ -4832,16 +4776,6 @@ unsafe extern "C" {
         count: *mut i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn umsg_vparse_72(
-        fmt: *const UMessageFormat,
-        source: *const UChar,
-        sourceLength: i32,
-        count: *mut i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -5023,6 +4957,233 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn uplrules_getKeywords_72(
         uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UResourceBundle {
+    _unused: [u8; 0],
+}
+impl UResType {
+    pub const RES_NONE: UResType = UResType::URES_NONE;
+}
+impl UResType {
+    pub const RES_STRING: UResType = UResType::URES_STRING;
+}
+impl UResType {
+    pub const RES_BINARY: UResType = UResType::URES_BINARY;
+}
+impl UResType {
+    pub const RES_TABLE: UResType = UResType::URES_TABLE;
+}
+impl UResType {
+    pub const RES_ALIAS: UResType = UResType::URES_ALIAS;
+}
+impl UResType {
+    pub const RES_INT: UResType = UResType::URES_INT;
+}
+impl UResType {
+    pub const RES_ARRAY: UResType = UResType::URES_ARRAY;
+}
+impl UResType {
+    pub const RES_INT_VECTOR: UResType = UResType::URES_INT_VECTOR;
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq, Eq)]
+pub enum UResType {
+    URES_NONE = -1,
+    URES_STRING = 0,
+    URES_BINARY = 1,
+    URES_TABLE = 2,
+    URES_ALIAS = 3,
+    URES_INT = 7,
+    URES_ARRAY = 8,
+    URES_INT_VECTOR = 14,
+    RES_RESERVED = 15,
+    URES_LIMIT = 16,
+}
+unsafe extern "C" {
+    pub fn ures_open_72(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openDirect_72(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openU_72(
+        packageName: *const UChar,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_countArrayItems_72(
+        resourceBundle: *const UResourceBundle,
+        resourceKey: *const ::std::os::raw::c_char,
+        err: *mut UErrorCode,
+    ) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_close_72(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_getVersionNumber_72(
+        resourceBundle: *const UResourceBundle,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getVersion_72(resB: *const UResourceBundle, versionInfo: *mut u8);
+}
+unsafe extern "C" {
+    pub fn ures_getLocale_72(
+        resourceBundle: *const UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getLocaleByType_72(
+        resourceBundle: *const UResourceBundle,
+        type_: ULocDataLocaleType,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openFillIn_72(
+        r: *mut UResourceBundle,
+        packageName: *const ::std::os::raw::c_char,
+        localeID: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    );
+}
+unsafe extern "C" {
+    pub fn ures_getString_72(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8String_72(
+        resB: *const UResourceBundle,
+        dest: *mut ::std::os::raw::c_char,
+        length: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getBinary_72(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const u8;
+}
+unsafe extern "C" {
+    pub fn ures_getIntVector_72(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const i32;
+}
+unsafe extern "C" {
+    pub fn ures_getUInt_72(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> u32;
+}
+unsafe extern "C" {
+    pub fn ures_getInt_72(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getSize_72(resourceBundle: *const UResourceBundle) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getType_72(resourceBundle: *const UResourceBundle) -> UResType;
+}
+unsafe extern "C" {
+    pub fn ures_getKey_72(resourceBundle: *const UResourceBundle) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_resetIterator_72(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_hasNext_72(resourceBundle: *const UResourceBundle) -> UBool;
+}
+unsafe extern "C" {
+    pub fn ures_getNextResource_72(
+        resourceBundle: *mut UResourceBundle,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getNextString_72(
+        resourceBundle: *mut UResourceBundle,
+        len: *mut i32,
+        key: *mut *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getByIndex_72(
+        resourceBundle: *const UResourceBundle,
+        indexR: i32,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByIndex_72(
+        resourceBundle: *const UResourceBundle,
+        indexS: i32,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByIndex_72(
+        resB: *const UResourceBundle,
+        stringIndex: i32,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getByKey_72(
+        resourceBundle: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByKey_72(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByKey_72(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openAvailableLocales_72(
+        packageName: *const ::std::os::raw::c_char,
         status: *mut UErrorCode,
     ) -> *mut UEnumeration;
 }
@@ -5839,7 +6000,6 @@ unsafe extern "C" {
         pErrorCode: *mut UErrorCode,
     ) -> *mut UCPTrie;
 }
-pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq)]
 pub struct __va_list_tag {

--- a/rust_icu_sys/bindgen/lib_73.rs
+++ b/rust_icu_sys/bindgen/lib_73.rs
@@ -4675,7 +4675,6 @@ unsafe extern "C" {
         status: *mut UErrorCode,
     );
 }
-pub type va_list = __builtin_va_list;
 unsafe extern "C" {
     pub fn u_formatMessage_73(
         locale: *const ::std::os::raw::c_char,
@@ -4688,17 +4687,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessage_73(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessage_73(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4707,17 +4695,6 @@ unsafe extern "C" {
         sourceLength: i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessage_73(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -4733,18 +4710,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessageWithError_73(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        parseError: *mut UParseError,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessageWithError_73(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4754,18 +4719,6 @@ unsafe extern "C" {
         parseError: *mut UParseError,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessageWithError_73(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        parseError: *mut UParseError,
-        status: *mut UErrorCode,
     );
 }
 pub type UMessageFormat = *mut ::std::os::raw::c_void;
@@ -4817,15 +4770,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn umsg_vformat_73(
-        fmt: *const UMessageFormat,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn umsg_parse_73(
         fmt: *const UMessageFormat,
         source: *const UChar,
@@ -4833,16 +4777,6 @@ unsafe extern "C" {
         count: *mut i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn umsg_vparse_73(
-        fmt: *const UMessageFormat,
-        source: *const UChar,
-        sourceLength: i32,
-        count: *mut i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -5024,6 +4958,233 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn uplrules_getKeywords_73(
         uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UResourceBundle {
+    _unused: [u8; 0],
+}
+impl UResType {
+    pub const RES_NONE: UResType = UResType::URES_NONE;
+}
+impl UResType {
+    pub const RES_STRING: UResType = UResType::URES_STRING;
+}
+impl UResType {
+    pub const RES_BINARY: UResType = UResType::URES_BINARY;
+}
+impl UResType {
+    pub const RES_TABLE: UResType = UResType::URES_TABLE;
+}
+impl UResType {
+    pub const RES_ALIAS: UResType = UResType::URES_ALIAS;
+}
+impl UResType {
+    pub const RES_INT: UResType = UResType::URES_INT;
+}
+impl UResType {
+    pub const RES_ARRAY: UResType = UResType::URES_ARRAY;
+}
+impl UResType {
+    pub const RES_INT_VECTOR: UResType = UResType::URES_INT_VECTOR;
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq, Eq)]
+pub enum UResType {
+    URES_NONE = -1,
+    URES_STRING = 0,
+    URES_BINARY = 1,
+    URES_TABLE = 2,
+    URES_ALIAS = 3,
+    URES_INT = 7,
+    URES_ARRAY = 8,
+    URES_INT_VECTOR = 14,
+    RES_RESERVED = 15,
+    URES_LIMIT = 16,
+}
+unsafe extern "C" {
+    pub fn ures_open_73(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openDirect_73(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openU_73(
+        packageName: *const UChar,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_countArrayItems_73(
+        resourceBundle: *const UResourceBundle,
+        resourceKey: *const ::std::os::raw::c_char,
+        err: *mut UErrorCode,
+    ) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_close_73(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_getVersionNumber_73(
+        resourceBundle: *const UResourceBundle,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getVersion_73(resB: *const UResourceBundle, versionInfo: *mut u8);
+}
+unsafe extern "C" {
+    pub fn ures_getLocale_73(
+        resourceBundle: *const UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getLocaleByType_73(
+        resourceBundle: *const UResourceBundle,
+        type_: ULocDataLocaleType,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openFillIn_73(
+        r: *mut UResourceBundle,
+        packageName: *const ::std::os::raw::c_char,
+        localeID: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    );
+}
+unsafe extern "C" {
+    pub fn ures_getString_73(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8String_73(
+        resB: *const UResourceBundle,
+        dest: *mut ::std::os::raw::c_char,
+        length: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getBinary_73(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const u8;
+}
+unsafe extern "C" {
+    pub fn ures_getIntVector_73(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const i32;
+}
+unsafe extern "C" {
+    pub fn ures_getUInt_73(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> u32;
+}
+unsafe extern "C" {
+    pub fn ures_getInt_73(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getSize_73(resourceBundle: *const UResourceBundle) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getType_73(resourceBundle: *const UResourceBundle) -> UResType;
+}
+unsafe extern "C" {
+    pub fn ures_getKey_73(resourceBundle: *const UResourceBundle) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_resetIterator_73(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_hasNext_73(resourceBundle: *const UResourceBundle) -> UBool;
+}
+unsafe extern "C" {
+    pub fn ures_getNextResource_73(
+        resourceBundle: *mut UResourceBundle,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getNextString_73(
+        resourceBundle: *mut UResourceBundle,
+        len: *mut i32,
+        key: *mut *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getByIndex_73(
+        resourceBundle: *const UResourceBundle,
+        indexR: i32,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByIndex_73(
+        resourceBundle: *const UResourceBundle,
+        indexS: i32,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByIndex_73(
+        resB: *const UResourceBundle,
+        stringIndex: i32,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getByKey_73(
+        resourceBundle: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByKey_73(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByKey_73(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openAvailableLocales_73(
+        packageName: *const ::std::os::raw::c_char,
         status: *mut UErrorCode,
     ) -> *mut UEnumeration;
 }
@@ -5840,7 +6001,6 @@ unsafe extern "C" {
         pErrorCode: *mut UErrorCode,
     ) -> *mut UCPTrie;
 }
-pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq)]
 pub struct __va_list_tag {

--- a/rust_icu_sys/bindgen/lib_74.rs
+++ b/rust_icu_sys/bindgen/lib_74.rs
@@ -4692,7 +4692,6 @@ unsafe extern "C" {
         status: *mut UErrorCode,
     );
 }
-pub type va_list = __builtin_va_list;
 unsafe extern "C" {
     pub fn u_formatMessage_74(
         locale: *const ::std::os::raw::c_char,
@@ -4705,17 +4704,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessage_74(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessage_74(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4724,17 +4712,6 @@ unsafe extern "C" {
         sourceLength: i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessage_74(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -4750,18 +4727,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessageWithError_74(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        parseError: *mut UParseError,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessageWithError_74(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4771,18 +4736,6 @@ unsafe extern "C" {
         parseError: *mut UParseError,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessageWithError_74(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        parseError: *mut UParseError,
-        status: *mut UErrorCode,
     );
 }
 pub type UMessageFormat = *mut ::std::os::raw::c_void;
@@ -4834,15 +4787,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn umsg_vformat_74(
-        fmt: *const UMessageFormat,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn umsg_parse_74(
         fmt: *const UMessageFormat,
         source: *const UChar,
@@ -4850,16 +4794,6 @@ unsafe extern "C" {
         count: *mut i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn umsg_vparse_74(
-        fmt: *const UMessageFormat,
-        source: *const UChar,
-        sourceLength: i32,
-        count: *mut i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -5041,6 +4975,233 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn uplrules_getKeywords_74(
         uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UResourceBundle {
+    _unused: [u8; 0],
+}
+impl UResType {
+    pub const RES_NONE: UResType = UResType::URES_NONE;
+}
+impl UResType {
+    pub const RES_STRING: UResType = UResType::URES_STRING;
+}
+impl UResType {
+    pub const RES_BINARY: UResType = UResType::URES_BINARY;
+}
+impl UResType {
+    pub const RES_TABLE: UResType = UResType::URES_TABLE;
+}
+impl UResType {
+    pub const RES_ALIAS: UResType = UResType::URES_ALIAS;
+}
+impl UResType {
+    pub const RES_INT: UResType = UResType::URES_INT;
+}
+impl UResType {
+    pub const RES_ARRAY: UResType = UResType::URES_ARRAY;
+}
+impl UResType {
+    pub const RES_INT_VECTOR: UResType = UResType::URES_INT_VECTOR;
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq, Eq)]
+pub enum UResType {
+    URES_NONE = -1,
+    URES_STRING = 0,
+    URES_BINARY = 1,
+    URES_TABLE = 2,
+    URES_ALIAS = 3,
+    URES_INT = 7,
+    URES_ARRAY = 8,
+    URES_INT_VECTOR = 14,
+    RES_RESERVED = 15,
+    URES_LIMIT = 16,
+}
+unsafe extern "C" {
+    pub fn ures_open_74(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openDirect_74(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openU_74(
+        packageName: *const UChar,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_countArrayItems_74(
+        resourceBundle: *const UResourceBundle,
+        resourceKey: *const ::std::os::raw::c_char,
+        err: *mut UErrorCode,
+    ) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_close_74(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_getVersionNumber_74(
+        resourceBundle: *const UResourceBundle,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getVersion_74(resB: *const UResourceBundle, versionInfo: *mut u8);
+}
+unsafe extern "C" {
+    pub fn ures_getLocale_74(
+        resourceBundle: *const UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getLocaleByType_74(
+        resourceBundle: *const UResourceBundle,
+        type_: ULocDataLocaleType,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openFillIn_74(
+        r: *mut UResourceBundle,
+        packageName: *const ::std::os::raw::c_char,
+        localeID: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    );
+}
+unsafe extern "C" {
+    pub fn ures_getString_74(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8String_74(
+        resB: *const UResourceBundle,
+        dest: *mut ::std::os::raw::c_char,
+        length: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getBinary_74(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const u8;
+}
+unsafe extern "C" {
+    pub fn ures_getIntVector_74(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const i32;
+}
+unsafe extern "C" {
+    pub fn ures_getUInt_74(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> u32;
+}
+unsafe extern "C" {
+    pub fn ures_getInt_74(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getSize_74(resourceBundle: *const UResourceBundle) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getType_74(resourceBundle: *const UResourceBundle) -> UResType;
+}
+unsafe extern "C" {
+    pub fn ures_getKey_74(resourceBundle: *const UResourceBundle) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_resetIterator_74(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_hasNext_74(resourceBundle: *const UResourceBundle) -> UBool;
+}
+unsafe extern "C" {
+    pub fn ures_getNextResource_74(
+        resourceBundle: *mut UResourceBundle,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getNextString_74(
+        resourceBundle: *mut UResourceBundle,
+        len: *mut i32,
+        key: *mut *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getByIndex_74(
+        resourceBundle: *const UResourceBundle,
+        indexR: i32,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByIndex_74(
+        resourceBundle: *const UResourceBundle,
+        indexS: i32,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByIndex_74(
+        resB: *const UResourceBundle,
+        stringIndex: i32,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getByKey_74(
+        resourceBundle: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByKey_74(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByKey_74(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openAvailableLocales_74(
+        packageName: *const ::std::os::raw::c_char,
         status: *mut UErrorCode,
     ) -> *mut UEnumeration;
 }
@@ -5857,7 +6018,6 @@ unsafe extern "C" {
         pErrorCode: *mut UErrorCode,
     ) -> *mut UCPTrie;
 }
-pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq)]
 pub struct __va_list_tag {

--- a/rust_icu_sys/bindgen/lib_76.rs
+++ b/rust_icu_sys/bindgen/lib_76.rs
@@ -4738,7 +4738,6 @@ unsafe extern "C" {
         status: *mut UErrorCode,
     );
 }
-pub type va_list = __builtin_va_list;
 unsafe extern "C" {
     pub fn u_formatMessage_76(
         locale: *const ::std::os::raw::c_char,
@@ -4751,17 +4750,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessage_76(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessage_76(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4770,17 +4758,6 @@ unsafe extern "C" {
         sourceLength: i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessage_76(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -4796,18 +4773,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessageWithError_76(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        parseError: *mut UParseError,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessageWithError_76(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4817,18 +4782,6 @@ unsafe extern "C" {
         parseError: *mut UParseError,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessageWithError_76(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        parseError: *mut UParseError,
-        status: *mut UErrorCode,
     );
 }
 pub type UMessageFormat = *mut ::std::os::raw::c_void;
@@ -4880,15 +4833,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn umsg_vformat_76(
-        fmt: *const UMessageFormat,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn umsg_parse_76(
         fmt: *const UMessageFormat,
         source: *const UChar,
@@ -4896,16 +4840,6 @@ unsafe extern "C" {
         count: *mut i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn umsg_vparse_76(
-        fmt: *const UMessageFormat,
-        source: *const UChar,
-        sourceLength: i32,
-        count: *mut i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -5087,6 +5021,233 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn uplrules_getKeywords_76(
         uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UResourceBundle {
+    _unused: [u8; 0],
+}
+impl UResType {
+    pub const RES_NONE: UResType = UResType::URES_NONE;
+}
+impl UResType {
+    pub const RES_STRING: UResType = UResType::URES_STRING;
+}
+impl UResType {
+    pub const RES_BINARY: UResType = UResType::URES_BINARY;
+}
+impl UResType {
+    pub const RES_TABLE: UResType = UResType::URES_TABLE;
+}
+impl UResType {
+    pub const RES_ALIAS: UResType = UResType::URES_ALIAS;
+}
+impl UResType {
+    pub const RES_INT: UResType = UResType::URES_INT;
+}
+impl UResType {
+    pub const RES_ARRAY: UResType = UResType::URES_ARRAY;
+}
+impl UResType {
+    pub const RES_INT_VECTOR: UResType = UResType::URES_INT_VECTOR;
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq, Eq)]
+pub enum UResType {
+    URES_NONE = -1,
+    URES_STRING = 0,
+    URES_BINARY = 1,
+    URES_TABLE = 2,
+    URES_ALIAS = 3,
+    URES_INT = 7,
+    URES_ARRAY = 8,
+    URES_INT_VECTOR = 14,
+    RES_RESERVED = 15,
+    URES_LIMIT = 16,
+}
+unsafe extern "C" {
+    pub fn ures_open_76(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openDirect_76(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openU_76(
+        packageName: *const UChar,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_countArrayItems_76(
+        resourceBundle: *const UResourceBundle,
+        resourceKey: *const ::std::os::raw::c_char,
+        err: *mut UErrorCode,
+    ) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_close_76(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_getVersionNumber_76(
+        resourceBundle: *const UResourceBundle,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getVersion_76(resB: *const UResourceBundle, versionInfo: *mut u8);
+}
+unsafe extern "C" {
+    pub fn ures_getLocale_76(
+        resourceBundle: *const UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getLocaleByType_76(
+        resourceBundle: *const UResourceBundle,
+        type_: ULocDataLocaleType,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openFillIn_76(
+        r: *mut UResourceBundle,
+        packageName: *const ::std::os::raw::c_char,
+        localeID: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    );
+}
+unsafe extern "C" {
+    pub fn ures_getString_76(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8String_76(
+        resB: *const UResourceBundle,
+        dest: *mut ::std::os::raw::c_char,
+        length: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getBinary_76(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const u8;
+}
+unsafe extern "C" {
+    pub fn ures_getIntVector_76(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const i32;
+}
+unsafe extern "C" {
+    pub fn ures_getUInt_76(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> u32;
+}
+unsafe extern "C" {
+    pub fn ures_getInt_76(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getSize_76(resourceBundle: *const UResourceBundle) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getType_76(resourceBundle: *const UResourceBundle) -> UResType;
+}
+unsafe extern "C" {
+    pub fn ures_getKey_76(resourceBundle: *const UResourceBundle) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_resetIterator_76(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_hasNext_76(resourceBundle: *const UResourceBundle) -> UBool;
+}
+unsafe extern "C" {
+    pub fn ures_getNextResource_76(
+        resourceBundle: *mut UResourceBundle,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getNextString_76(
+        resourceBundle: *mut UResourceBundle,
+        len: *mut i32,
+        key: *mut *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getByIndex_76(
+        resourceBundle: *const UResourceBundle,
+        indexR: i32,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByIndex_76(
+        resourceBundle: *const UResourceBundle,
+        indexS: i32,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByIndex_76(
+        resB: *const UResourceBundle,
+        stringIndex: i32,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getByKey_76(
+        resourceBundle: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByKey_76(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByKey_76(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openAvailableLocales_76(
+        packageName: *const ::std::os::raw::c_char,
         status: *mut UErrorCode,
     ) -> *mut UEnumeration;
 }
@@ -5903,7 +6064,6 @@ unsafe extern "C" {
         pErrorCode: *mut UErrorCode,
     ) -> *mut UCPTrie;
 }
-pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq)]
 pub struct __va_list_tag {

--- a/rust_icu_sys/bindgen/lib_77.rs
+++ b/rust_icu_sys/bindgen/lib_77.rs
@@ -4739,7 +4739,6 @@ unsafe extern "C" {
         status: *mut UErrorCode,
     );
 }
-pub type va_list = __builtin_va_list;
 unsafe extern "C" {
     pub fn u_formatMessage_77(
         locale: *const ::std::os::raw::c_char,
@@ -4752,17 +4751,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessage_77(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessage_77(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4771,17 +4759,6 @@ unsafe extern "C" {
         sourceLength: i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessage_77(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -4797,18 +4774,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessageWithError_77(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        parseError: *mut UParseError,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessageWithError_77(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4818,18 +4783,6 @@ unsafe extern "C" {
         parseError: *mut UParseError,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessageWithError_77(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        parseError: *mut UParseError,
-        status: *mut UErrorCode,
     );
 }
 pub type UMessageFormat = *mut ::std::os::raw::c_void;
@@ -4881,15 +4834,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn umsg_vformat_77(
-        fmt: *const UMessageFormat,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn umsg_parse_77(
         fmt: *const UMessageFormat,
         source: *const UChar,
@@ -4897,16 +4841,6 @@ unsafe extern "C" {
         count: *mut i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn umsg_vparse_77(
-        fmt: *const UMessageFormat,
-        source: *const UChar,
-        sourceLength: i32,
-        count: *mut i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -5088,6 +5022,233 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn uplrules_getKeywords_77(
         uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UResourceBundle {
+    _unused: [u8; 0],
+}
+impl UResType {
+    pub const RES_NONE: UResType = UResType::URES_NONE;
+}
+impl UResType {
+    pub const RES_STRING: UResType = UResType::URES_STRING;
+}
+impl UResType {
+    pub const RES_BINARY: UResType = UResType::URES_BINARY;
+}
+impl UResType {
+    pub const RES_TABLE: UResType = UResType::URES_TABLE;
+}
+impl UResType {
+    pub const RES_ALIAS: UResType = UResType::URES_ALIAS;
+}
+impl UResType {
+    pub const RES_INT: UResType = UResType::URES_INT;
+}
+impl UResType {
+    pub const RES_ARRAY: UResType = UResType::URES_ARRAY;
+}
+impl UResType {
+    pub const RES_INT_VECTOR: UResType = UResType::URES_INT_VECTOR;
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq, Eq)]
+pub enum UResType {
+    URES_NONE = -1,
+    URES_STRING = 0,
+    URES_BINARY = 1,
+    URES_TABLE = 2,
+    URES_ALIAS = 3,
+    URES_INT = 7,
+    URES_ARRAY = 8,
+    URES_INT_VECTOR = 14,
+    RES_RESERVED = 15,
+    URES_LIMIT = 16,
+}
+unsafe extern "C" {
+    pub fn ures_open_77(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openDirect_77(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openU_77(
+        packageName: *const UChar,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_countArrayItems_77(
+        resourceBundle: *const UResourceBundle,
+        resourceKey: *const ::std::os::raw::c_char,
+        err: *mut UErrorCode,
+    ) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_close_77(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_getVersionNumber_77(
+        resourceBundle: *const UResourceBundle,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getVersion_77(resB: *const UResourceBundle, versionInfo: *mut u8);
+}
+unsafe extern "C" {
+    pub fn ures_getLocale_77(
+        resourceBundle: *const UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getLocaleByType_77(
+        resourceBundle: *const UResourceBundle,
+        type_: ULocDataLocaleType,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openFillIn_77(
+        r: *mut UResourceBundle,
+        packageName: *const ::std::os::raw::c_char,
+        localeID: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    );
+}
+unsafe extern "C" {
+    pub fn ures_getString_77(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8String_77(
+        resB: *const UResourceBundle,
+        dest: *mut ::std::os::raw::c_char,
+        length: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getBinary_77(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const u8;
+}
+unsafe extern "C" {
+    pub fn ures_getIntVector_77(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const i32;
+}
+unsafe extern "C" {
+    pub fn ures_getUInt_77(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> u32;
+}
+unsafe extern "C" {
+    pub fn ures_getInt_77(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getSize_77(resourceBundle: *const UResourceBundle) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getType_77(resourceBundle: *const UResourceBundle) -> UResType;
+}
+unsafe extern "C" {
+    pub fn ures_getKey_77(resourceBundle: *const UResourceBundle) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_resetIterator_77(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_hasNext_77(resourceBundle: *const UResourceBundle) -> UBool;
+}
+unsafe extern "C" {
+    pub fn ures_getNextResource_77(
+        resourceBundle: *mut UResourceBundle,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getNextString_77(
+        resourceBundle: *mut UResourceBundle,
+        len: *mut i32,
+        key: *mut *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getByIndex_77(
+        resourceBundle: *const UResourceBundle,
+        indexR: i32,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByIndex_77(
+        resourceBundle: *const UResourceBundle,
+        indexS: i32,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByIndex_77(
+        resB: *const UResourceBundle,
+        stringIndex: i32,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getByKey_77(
+        resourceBundle: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByKey_77(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByKey_77(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openAvailableLocales_77(
+        packageName: *const ::std::os::raw::c_char,
         status: *mut UErrorCode,
     ) -> *mut UEnumeration;
 }
@@ -5904,7 +6065,6 @@ unsafe extern "C" {
         pErrorCode: *mut UErrorCode,
     ) -> *mut UCPTrie;
 }
-pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq)]
 pub struct __va_list_tag {

--- a/rust_icu_sys/bindgen/lib_78.rs
+++ b/rust_icu_sys/bindgen/lib_78.rs
@@ -4741,7 +4741,6 @@ unsafe extern "C" {
         status: *mut UErrorCode,
     );
 }
-pub type va_list = __builtin_va_list;
 unsafe extern "C" {
     pub fn u_formatMessage_78(
         locale: *const ::std::os::raw::c_char,
@@ -4754,17 +4753,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessage_78(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessage_78(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4773,17 +4761,6 @@ unsafe extern "C" {
         sourceLength: i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessage_78(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -4799,18 +4776,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn u_vformatMessageWithError_78(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        result: *mut UChar,
-        resultLength: i32,
-        parseError: *mut UParseError,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn u_parseMessageWithError_78(
         locale: *const ::std::os::raw::c_char,
         pattern: *const UChar,
@@ -4820,18 +4785,6 @@ unsafe extern "C" {
         parseError: *mut UParseError,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn u_vparseMessageWithError_78(
-        locale: *const ::std::os::raw::c_char,
-        pattern: *const UChar,
-        patternLength: i32,
-        source: *const UChar,
-        sourceLength: i32,
-        ap: *mut __va_list_tag,
-        parseError: *mut UParseError,
-        status: *mut UErrorCode,
     );
 }
 pub type UMessageFormat = *mut ::std::os::raw::c_void;
@@ -4883,15 +4836,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 unsafe extern "C" {
-    pub fn umsg_vformat_78(
-        fmt: *const UMessageFormat,
-        result: *mut UChar,
-        resultLength: i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
-    ) -> i32;
-}
-unsafe extern "C" {
     pub fn umsg_parse_78(
         fmt: *const UMessageFormat,
         source: *const UChar,
@@ -4899,16 +4843,6 @@ unsafe extern "C" {
         count: *mut i32,
         status: *mut UErrorCode,
         ...
-    );
-}
-unsafe extern "C" {
-    pub fn umsg_vparse_78(
-        fmt: *const UMessageFormat,
-        source: *const UChar,
-        sourceLength: i32,
-        count: *mut i32,
-        ap: *mut __va_list_tag,
-        status: *mut UErrorCode,
     );
 }
 unsafe extern "C" {
@@ -5090,6 +5024,233 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn uplrules_getKeywords_78(
         uplrules: *const UPluralRules,
+        status: *mut UErrorCode,
+    ) -> *mut UEnumeration;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct UResourceBundle {
+    _unused: [u8; 0],
+}
+impl UResType {
+    pub const RES_NONE: UResType = UResType::URES_NONE;
+}
+impl UResType {
+    pub const RES_STRING: UResType = UResType::URES_STRING;
+}
+impl UResType {
+    pub const RES_BINARY: UResType = UResType::URES_BINARY;
+}
+impl UResType {
+    pub const RES_TABLE: UResType = UResType::URES_TABLE;
+}
+impl UResType {
+    pub const RES_ALIAS: UResType = UResType::URES_ALIAS;
+}
+impl UResType {
+    pub const RES_INT: UResType = UResType::URES_INT;
+}
+impl UResType {
+    pub const RES_ARRAY: UResType = UResType::URES_ARRAY;
+}
+impl UResType {
+    pub const RES_INT_VECTOR: UResType = UResType::URES_INT_VECTOR;
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq, Eq)]
+pub enum UResType {
+    URES_NONE = -1,
+    URES_STRING = 0,
+    URES_BINARY = 1,
+    URES_TABLE = 2,
+    URES_ALIAS = 3,
+    URES_INT = 7,
+    URES_ARRAY = 8,
+    URES_INT_VECTOR = 14,
+    RES_RESERVED = 15,
+    URES_LIMIT = 16,
+}
+unsafe extern "C" {
+    pub fn ures_open_78(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openDirect_78(
+        packageName: *const ::std::os::raw::c_char,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_openU_78(
+        packageName: *const UChar,
+        locale: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_countArrayItems_78(
+        resourceBundle: *const UResourceBundle,
+        resourceKey: *const ::std::os::raw::c_char,
+        err: *mut UErrorCode,
+    ) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_close_78(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_getVersionNumber_78(
+        resourceBundle: *const UResourceBundle,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getVersion_78(resB: *const UResourceBundle, versionInfo: *mut u8);
+}
+unsafe extern "C" {
+    pub fn ures_getLocale_78(
+        resourceBundle: *const UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getLocaleByType_78(
+        resourceBundle: *const UResourceBundle,
+        type_: ULocDataLocaleType,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openFillIn_78(
+        r: *mut UResourceBundle,
+        packageName: *const ::std::os::raw::c_char,
+        localeID: *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    );
+}
+unsafe extern "C" {
+    pub fn ures_getString_78(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8String_78(
+        resB: *const UResourceBundle,
+        dest: *mut ::std::os::raw::c_char,
+        length: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getBinary_78(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const u8;
+}
+unsafe extern "C" {
+    pub fn ures_getIntVector_78(
+        resourceBundle: *const UResourceBundle,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const i32;
+}
+unsafe extern "C" {
+    pub fn ures_getUInt_78(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> u32;
+}
+unsafe extern "C" {
+    pub fn ures_getInt_78(resourceBundle: *const UResourceBundle, status: *mut UErrorCode) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getSize_78(resourceBundle: *const UResourceBundle) -> i32;
+}
+unsafe extern "C" {
+    pub fn ures_getType_78(resourceBundle: *const UResourceBundle) -> UResType;
+}
+unsafe extern "C" {
+    pub fn ures_getKey_78(resourceBundle: *const UResourceBundle) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_resetIterator_78(resourceBundle: *mut UResourceBundle);
+}
+unsafe extern "C" {
+    pub fn ures_hasNext_78(resourceBundle: *const UResourceBundle) -> UBool;
+}
+unsafe extern "C" {
+    pub fn ures_getNextResource_78(
+        resourceBundle: *mut UResourceBundle,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getNextString_78(
+        resourceBundle: *mut UResourceBundle,
+        len: *mut i32,
+        key: *mut *const ::std::os::raw::c_char,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getByIndex_78(
+        resourceBundle: *const UResourceBundle,
+        indexR: i32,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByIndex_78(
+        resourceBundle: *const UResourceBundle,
+        indexS: i32,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByIndex_78(
+        resB: *const UResourceBundle,
+        stringIndex: i32,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_getByKey_78(
+        resourceBundle: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        fillIn: *mut UResourceBundle,
+        status: *mut UErrorCode,
+    ) -> *mut UResourceBundle;
+}
+unsafe extern "C" {
+    pub fn ures_getStringByKey_78(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        len: *mut i32,
+        status: *mut UErrorCode,
+    ) -> *const UChar;
+}
+unsafe extern "C" {
+    pub fn ures_getUTF8StringByKey_78(
+        resB: *const UResourceBundle,
+        key: *const ::std::os::raw::c_char,
+        dest: *mut ::std::os::raw::c_char,
+        pLength: *mut i32,
+        forceCopy: UBool,
+        status: *mut UErrorCode,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ures_openAvailableLocales_78(
+        packageName: *const ::std::os::raw::c_char,
         status: *mut UErrorCode,
     ) -> *mut UEnumeration;
 }
@@ -5906,7 +6067,6 @@ unsafe extern "C" {
         pErrorCode: *mut UErrorCode,
     ) -> *mut UCPTrie;
 }
-pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq)]
 pub struct __va_list_tag {


### PR DESCRIPTION
## Summary

- Regenerates all `lib_XX.rs` pre-generated bindgen files in `rust_icu_sys/bindgen/` for ICU versions 63, 71, 72, 73, 74, 76, 77, and 78.
- Adds `ures_*`, `UResourceBundle`, and `UResType` symbols (74 per version) to support the forthcoming `rust_icu_ures` crate.
- Removes `va_list`, `__builtin_va_list`, `__gnuc_va_list` types and `u_vformatMessage.*`/`umsg_vformat.*` functions via blocklist entries, eliminating platform-dependent type definitions from the generated output.

The allowlist and blocklist entries were already present in `build.rs` and `run_bindgen.sh`; this PR applies them to the pre-generated static files by running `make static-bindgen` against the Docker-based test environments.

## Test plan

- [ ] CI `test-bindgen` job validates the static bindgen files compile correctly
- [ ] CI `test-with-features` matrix covers the `icu_version_in_env` path that uses these files

This commit was created by an automated coding assistant, with human
supervision.