### PR TITLE
fix(sys): add __va_list_tag to bindgen blocklist

### DIFF
--- a/rust_icu_sys/bindgen/run_bindgen.sh
+++ b/rust_icu_sys/bindgen/run_bindgen.sh
@@ -166,6 +166,7 @@ readonly BINDGEN_BLOCKLIST_TYPES=(
         "va_list"
         "__builtin_va_list"
         "__gnuc_va_list"
+        "__va_list_tag"
 )
 
 _bindgen="bindgen"

--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -116,6 +116,7 @@ mod inner {
             "va_list",
             "__builtin_va_list",
             "__gnuc_va_list",
+            "__va_list_tag",
         ];
 
         // C types that will be made available to rust code.  Add more to this list if you want to


### PR DESCRIPTION
## Summary

- Adds `__va_list_tag` to `BINDGEN_BLOCKLIST_TYPES` in both `build.rs` and `run_bindgen.sh`

On Linux x86_64, glibc defines `va_list` as a concrete struct named `__va_list_tag`. The existing blocklist covered `va_list`, `__builtin_va_list`, and `__gnuc_va_list` but missed `__va_list_tag`, causing it to appear in Docker-generated static bindgen output. This brings the Linux code path into parity with macOS, which uses `__builtin_va_list` (a compiler builtin with no struct definition).

## Test plan

- [ ] Regenerate static bindgen files via `make static-bindgen` and confirm zero occurrences of `__va_list_tag` in all `lib_XX.rs` files

This commit was created by an automated coding assistant, with human supervision.