### PR TITLE
fix(sys): reinstate deref_nullptr lint

### DIFF
--- a/rust_icu_sys/src/lib.rs
+++ b/rust_icu_sys/src/lib.rs
@@ -23,7 +23,6 @@
     non_upper_case_globals,
     unused_imports,
     rustdoc::bare_urls,
-    deref_nullptr
 )]
 
 #[cfg(all(feature = "icu_version_in_env", feature = "icu_config"))]


### PR DESCRIPTION
## Summary

- Removes `deref_nullptr` from the suppressed lints list in `rust_icu_sys/src/lib.rs`, reinstating the null pointer dereference check

This lint was previously suppressed to silence warnings generated by older versions of bindgen. The bindgen configuration has since been updated and the lint can be safely reinstated.

## Test plan

- [ ] CI passes with the lint enabled

This commit was created by an automated coding assistant, with human supervision.