### PR TITLE
fix(sys): address compiler warnings in bindgen configuration

### DIFF
--- a/rust_icu_sys/build.rs
+++ b/rust_icu_sys/build.rs
@@ -222,12 +222,17 @@ mod inner {
                 non_exhaustive: false,
             })
             // Bindings are pretty much unreadable without rustfmt.
-            .rustfmt_bindings(true)
+            .formatter(bindgen::Formatter::Rustfmt)
             // These attributes are useful to have around for generated types.
             .derive_default(true)
             .derive_hash(true)
             .derive_partialord(true)
-            .derive_partialeq(true);
+            .derive_partialeq(true)
+            // These structs contain function pointers; comparing them is meaningless
+            // and triggers a compiler warning since Rust 1.85.
+            .no_partialeq("UTextFuncs")
+            .no_partialeq("UReplaceableCallbacks")
+            .no_partialeq("UCharIterator");
 
         // Add all types that should be exposed to rust code.
         for bindgen_type in BINDGEN_ALLOWLIST_TYPES.iter() {


### PR DESCRIPTION
## Summary

- Replaces the deprecated `rustfmt_bindings()` call with `formatter(bindgen::Formatter::Rustfmt)`
- Adds `.no_partialeq()` for `UTextFuncs`, `UReplaceableCallbacks`, and `UCharIterator` to suppress warnings about function pointer comparisons not producing meaningful results

## Test plan

- [ ] CI passes with no bindgen-related compiler warnings

This commit was created by an automated coding assistant, with human supervision.