### PR TITLE
⚡ perf: replace expect(&format!(...)) with unwrap_or_else to avoid unnecessary allocations

### DIFF
--- a/rust_icu_ecma402/src/datetimeformat.rs
+++ b/rust_icu_ecma402/src/datetimeformat.rs
@@ -385,7 +385,7 @@ mod testing {
                     let mut result = String::new();
                     formatter
                         .format(*d, &mut result)
-                        .expect(&format!("can format: {}", d));
+                        .unwrap_or_else(|e| panic!("can format: {}: {:?}", d, e));
                     result
                 })
                 .collect();

--- a/rust_icu_ecma402/src/numberformat.rs
+++ b/rust_icu_ecma402/src/numberformat.rs
@@ -324,10 +324,11 @@ mod testing {
         ];
         for test in tests {
             let locale = crate::Locale::FromULoc(
-                uloc::ULoc::try_from(test.locale).expect(&format!("locale exists: {:?}", &test)),
+                uloc::ULoc::try_from(test.locale)
+                    .unwrap_or_else(|e| panic!("locale exists: {:?}: {:?}", &test, e)),
             );
             let format = crate::numberformat::NumberFormat::try_new(locale, test.clone().opts)
-                .expect(&format!("try_from should succeed: {:?}", &test));
+                .unwrap_or_else(|e| panic!("try_from should succeed: {:?}: {:?}", &test, e));
             let actual = test
                 .numbers
                 .iter()
@@ -335,7 +336,7 @@ mod testing {
                     let mut result = String::new();
                     format
                         .format(*n, &mut result)
-                        .expect(&format!("formatting succeeded for: {:?}", &test));
+                        .unwrap_or_else(|e| panic!("formatting succeeded for: {:?}: {:?}", &test, e));
                     result
                 })
                 .collect::<Vec<String>>();


### PR DESCRIPTION
💡 **What:** Replaced the use of `.expect(&format!(...))` with `.unwrap_or_else(|e| panic!(...))` in the test suites of `rust_icu_ecma402/src/numberformat.rs` and `rust_icu_ecma402/src/datetimeformat.rs`.
🎯 **Why:** The `format!` macro allocates a new `String` every time it's called. When used inside `expect()`, this allocation happens on every execution, including the success path. Using `unwrap_or_else` ensures that formatting and allocation only occur if a panic is actually triggered.
📊 **Measured Improvement:** A meaningful performance improvement could not be demonstrated via benchmarks due to environment limitations (missing `libicu-dev` and inability to download crates offline). However, this is a standard Rust performance optimization that eliminates unnecessary allocations in hot paths or frequently run tests.

This commit was created by an automated coding assistant, with human supervision.

---
*PR created automatically by Jules for task [12913409335323361221](https://jules.google.com/task/12913409335323361221) started by @filmil*