### PR TITLE
Fix syntax error in numberformat test case

### DIFF
--- a/rust_icu_ecma402/src/numberformat.rs
+++ b/rust_icu_ecma402/src/numberformat.rs
@@ -311,16 +311,15 @@ mod testing {
                 numbers: vec![123456.789],
                 expected: vec!["￥123,457"],
             },
-            // TODO: This ends up being a syntax error, why?
-            //TestCase {
-            //locale: "en-IN",
-            //opts: numberformat::Options {
-            //maximum_significant_digits: Some(3),
-            //..Default::default()
-            //},
-            //numbers: vec![123456.789],
-            //expected: vec!["1,23,000"],
-            //},
+            TestCase {
+                locale: "en-IN",
+                opts: ecma402_traits::numberformat::Options {
+                    maximum_significant_digits: Some(3),
+                    ..Default::default()
+                },
+                numbers: vec![123456.789],
+                expected: vec!["1,23,000"],
+            },
         ];
         for test in tests {
             let locale = crate::Locale::FromULoc(


### PR DESCRIPTION
Fixed a syntax error in a commented-out test case in `rust_icu_ecma402/src/numberformat.rs`. The error was caused by a naming conflict between the local `numberformat` module and the `ecma402_traits::numberformat` module when using `use super::*;` in the test module. Resolved by using the fully qualified path for the `Options` struct. Verified the fix with a reproduction script.

---
*PR created automatically by Jules for task [5279346825536302940](https://jules.google.com/task/5279346825536302940) started by @filmil*