### PR TITLE
fix: address compiler warnings across crates

### DIFF
--- a/rust_icu_common/tests/hygiene.rs
+++ b/rust_icu_common/tests/hygiene.rs
@@ -1,5 +1,6 @@
 #![no_implicit_prelude]
 
+#[allow(dead_code)]
 struct Type {
     rep: ::std::ptr::NonNull<::rust_icu_sys::UMessageFormat>,
 }

--- a/rust_icu_ucnv/src/utf8.rs
+++ b/rust_icu_ucnv/src/utf8.rs
@@ -125,14 +125,14 @@ impl Converter {
         self.converter.reset_to_uchars();
         self.utf8.reset_from_uchars();
         self.pivot_to_source = self.pivot_to.start;
-        self.pivot_to_target = self.pivot_to_target;
+        self.pivot_to_target = self.pivot_to.start;
     }
 
     pub fn reset_from_utf8(&mut self) {
         self.utf8.reset_to_uchars();
         self.converter.reset_from_uchars();
         self.pivot_from_source = self.pivot_from.start;
-        self.pivot_from_target = self.pivot_from_target;
+        self.pivot_from_target = self.pivot_from.start;
     }
 
     pub fn feed_to_utf8(&mut self, dst: &mut [u8], src: &[u8]) -> FeedResult {

--- a/rust_icu_ucsdet/src/lib.rs
+++ b/rust_icu_ucsdet/src/lib.rs
@@ -111,7 +111,7 @@ impl<'detector> CharsetDetector<'detector> {
     }
 
     /// Return the charset that best matches the supplied input data.
-    pub fn detect(&self) -> Result<CharsetMatch, common::Error> {
+    pub fn detect(&self) -> Result<CharsetMatch<'_>, common::Error> {
         let mut status = sys::UErrorCode::U_ZERO_ERROR;
         let charset_match =
             unsafe { versioned_function!(ucsdet_detect)(self.rep.as_ptr(), &mut status) };
@@ -128,7 +128,7 @@ impl<'detector> CharsetDetector<'detector> {
     /// The results are ordered with the best quality match first.
     ///
     /// Returns `&[CharsetMatch]` if no error.
-    pub fn detect_all(&self) -> Result<&[CharsetMatch], common::Error> {
+    pub fn detect_all(&self) -> Result<&[CharsetMatch<'_>], common::Error> {
         let mut status = sys::UErrorCode::U_ZERO_ERROR;
         let mut len = 0;
         let charset_match = unsafe {

--- a/rust_icu_udata/src/lib.rs
+++ b/rust_icu_udata/src/lib.rs
@@ -24,6 +24,9 @@ use {
 #[derive(Debug)]
 enum Rep {
     /// The data memory is backed by a user-supplied buffer.
+    /// The Vec<u8> is never read; it exists solely to keep the buffer alive
+    /// while ICU holds a raw pointer to it via udata_setCommonData.
+    #[allow(dead_code)]
     Buffer(Vec<u8>),
     /// The data memory is backed by a resource file.
     Resource(


### PR DESCRIPTION
## Summary

- `rust_icu_udata`: adds `#[allow(dead_code)]` to `Rep::Buffer(Vec<u8>)` — this variant intentionally keeps ICU's raw pointer alive and is never read directly
- `rust_icu_ucnv`: fixes copy-paste bug in pivot buffer reset functions where `pivot_to_target` and `pivot_from_target` were each assigned to themselves instead of their respective `start` pointers
- `rust_icu_ucsdet`: makes the anonymous lifetime explicit in `detect()` and `detect_all()` return types (`CharsetMatch` → `CharsetMatch<'_>`)
- `rust_icu_common`: adds `#[allow(dead_code)]` to the `Type` struct in the hygiene test, which exists solely to exercise `simple_drop_impl!` under `#![no_implicit_prelude]` and is never constructed

## Test plan

- [ ] CI passes with no compiler warnings

This commit was created by an automated coding assistant, with human supervision.