### PR TITLE
ci: enforce warnings as errors in test entrypoints

### DIFF
--- a/build/entrypoint-test-current.sh
+++ b/build/entrypoint-test-current.sh
@@ -25,6 +25,7 @@ env
 function run_cargo_test() {
   env LD_LIBRARY_PATH="${ICU_LIBRARY_PATH}/lib" \
       PKG_CONFIG_LIBDIR="${ICU_LIBRARY_PATH}/lib/pkgconfig" \
+      RUSTFLAGS="-D warnings" \
       cargo test \
           ${_local_cargo_options} \
             ${CARGO_TEST_ARGS}
@@ -33,6 +34,7 @@ function run_cargo_test() {
 function run_cargo_doc() {
   env LD_LIBRARY_PATH="${ICU_LIBRARY_PATH}/lib" \
       PKG_CONFIG_LIBDIR="${ICU_LIBRARY_PATH}/lib/pkgconfig" \
+      RUSTFLAGS="-D warnings" \
       cargo doc ${_local_cargo_options} ${CARGO_TEST_ARGS}
 }
 

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -11,11 +11,11 @@ readonly __all_dirs="$(ls -d rust_icu_*)"
 env
 
 function run_cargo_test() {
-  env LD_LIBRARY_PATH="/usr/local/lib" cargo test ${CARGO_TEST_ARGS}
+  env LD_LIBRARY_PATH="/usr/local/lib" RUSTFLAGS="-D warnings" cargo test ${CARGO_TEST_ARGS}
 }
 
 function run_cargo_doc() {
-  env LD_LIBRARY_PATH="/usr/local/lib" cargo doc ${CARGO_TEST_ARGS}
+  env LD_LIBRARY_PATH="/usr/local/lib" RUSTFLAGS="-D warnings" cargo doc ${CARGO_TEST_ARGS}
 }
 
 # Running cargo test or doc in the top level directory actually does nothing.


### PR DESCRIPTION
## Summary

- Adds `RUSTFLAGS="-D warnings"` to `run_cargo_test()` and `run_cargo_doc()` in `build/entrypoint.sh`

All compiler warnings have been addressed in the preceding PRs (#349, #350, #356). This commit promotes warnings to errors in CI to prevent regressions.

## Test plan

- [ ] CI passes with `-D warnings` enabled
- [ ] No new compiler warnings are introduced

This commit was created by an automated coding assistant, with human supervision.