### PR TITLE
chore(actions): bump actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/buildenv.yml
+++ b/.github/workflows/buildenv.yml
@@ -22,6 +22,6 @@ jobs:
   test-buildenv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build and test buildenv images
         run: make -C build VERSION=test test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         icu_version: [74, 76, 77]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Test ICU version ${{ matrix.icu_version }}'
         run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version}} docker-test'
   test-with-features:
@@ -29,13 +29,13 @@ jobs:
           - "renaming,icu_version_in_env,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus"
           - "renaming,icu_version_64_plus,icu_version_67_plus,icu_version_68_plus,icu_config,use-bindgen"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Test ICU version ${{ matrix.icu_version }}'
         run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version }} RUST_ICU_MAJOR_VERSION_NUMBER=${{ matrix.icu_version }} DOCKER_TEST_CARGO_TEST_ARGS="--no-default-features --features ${{ matrix.feature_set }}" docker-test'
   test-bindgen:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Test static-bindgen'
         run: 'make static-bindgen'
   test-static-linking:
@@ -44,7 +44,7 @@ jobs:
       matrix:
         runs-on: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - if: matrix.runs-on == 'macos-latest'
         run: make macos-test
       - if: matrix.runs-on == 'ubuntu-latest'
@@ -55,7 +55,7 @@ jobs:
       matrix:
         icu_version: [77]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Test ICU `main`'
         run: |
           make DOCKER_TEST_ENV=rust_icu_testenv-current RUST_ICU_MAJOR_VERSION_NUMBER=${{matrix.icu_version}} docker-test-current


### PR DESCRIPTION
## Summary

Bumps `actions/checkout` from v4 to v6 in `.github/workflows/test.yml` and `.github/workflows/buildenv.yml`.

`actions/checkout@v4` runs on Node.js 20, which is deprecated on GitHub Actions runners and will be removed on September 16, 2026. v6 uses Node.js 24.

## Test plan

- [ ] CI runs without the Node.js 20 deprecation warning

This commit was created by an automated coding assistant, with human supervision.