### PR TITLE
feat: Release version 5.7.0

### DIFF
--- a/ecma402_traits/Cargo.toml
+++ b/ecma402_traits/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "ecma402_traits"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Rust implementation of type traits to support ECMA 402 specification in Rust.

--- a/rust_icu/Cargo.toml
+++ b/rust_icu/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,23 +17,23 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "5.6.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "5.6.0", default-features = false }
-rust_icu_ucol = { path = "../rust_icu_ucol", version = "5.6.0", default-features = false }
-rust_icu_ucsdet = { path = "../rust_icu_ucsdet", version = "5.6.0", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "5.6.0", default-features = false }
-rust_icu_udata = { path = "../rust_icu_udata", version = "5.6.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.6.0", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "5.6.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.6.0", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "5.6.0", default-features = false }
-rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "5.6.0", default-features = false }
-rust_icu_ures   = { path = "../rust_icu_ures",   version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
-rust_icu_utext = { path = "../rust_icu_utext", version = "5.6.0", default-features = false }
-rust_icu_utrans = { path = "../rust_icu_utrans", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_ubrk = { path = "../rust_icu_ubrk", version = "5.7.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "5.7.0", default-features = false }
+rust_icu_ucol = { path = "../rust_icu_ucol", version = "5.7.0", default-features = false }
+rust_icu_ucsdet = { path = "../rust_icu_ucsdet", version = "5.7.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "5.7.0", default-features = false }
+rust_icu_udata = { path = "../rust_icu_udata", version = "5.7.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.7.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "5.7.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.7.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "5.7.0", default-features = false }
+rust_icu_unorm2 = { path = "../rust_icu_unorm2", version = "5.7.0", default-features = false }
+rust_icu_ures   = { path = "../rust_icu_ures",   version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
+rust_icu_utext = { path = "../rust_icu_utext", version = "5.7.0", default-features = false }
+rust_icu_utrans = { path = "../rust_icu_utrans", version = "5.7.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_common/Cargo.toml
+++ b/rust_icu_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_common"
-version = "5.6.0"
+version = "5.7.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 thiserror = "1.0.9"
 
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false}
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false}
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ecma402/Cargo.toml
+++ b/rust_icu_ecma402/Cargo.toml
@@ -6,25 +6,25 @@ license = "Apache-2.0"
 name = "rust_icu_ecma402"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 ECMA 402 standard implementation in Rust.
 """
 [dependencies]
 anyhow = "1.0.25"
-ecma402_traits = { path = "../ecma402_traits", version = "5.6.0" }
+ecma402_traits = { path = "../ecma402_traits", version = "5.7.0" }
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_udat = { path = "../rust_icu_udat", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
-rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "5.6.0", default-features = false }
-rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "5.6.0", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "5.6.0", default-features = false }
-rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_udat = { path = "../rust_icu_udat", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
+rust_icu_ulistformatter = { path = "../rust_icu_ulistformatter", version = "5.7.0", default-features = false }
+rust_icu_upluralrules = { path = "../rust_icu_upluralrules", version = "5.7.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "5.7.0", default-features = false }
+rust_icu_unumberformatter = { path = "../rust_icu_unumberformatter", version = "5.7.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_intl/Cargo.toml
+++ b/rust_icu_intl/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_intl"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,11 +17,11 @@ umsg.h
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.6.0", default-features = false }
-rust_icu_umsg = { path = "../rust_icu_umsg", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.7.0", default-features = false }
+rust_icu_umsg = { path = "../rust_icu_umsg", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 thiserror = "1.0.9"
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.

--- a/rust_icu_release/Cargo.toml
+++ b/rust_icu_release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_release"
-version = "5.6.0"
+version = "5.7.0"
 edition = "2024"
 authors = ["Google Inc."]
 license = "Apache-2.0"

--- a/rust_icu_sys/Cargo.toml
+++ b/rust_icu_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_icu_sys"
-version = "5.6.0"
+version = "5.7.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -24,7 +24,7 @@ paste = "1.0"
 anyhow = "1.0.72"
 bindgen = { version = "0.69.5", optional = true }
 lazy_static = "1.4"
-rust_icu_release = { path = "../rust_icu_release", version = "5.6.0" }
+rust_icu_release = { path = "../rust_icu_release", version = "5.7.0" }
 
 [lib]
 # Indented documentation text in the generated library is prose, not rust code.

--- a/rust_icu_ubrk/Cargo.toml
+++ b/rust_icu_ubrk/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_ubrk"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_ucal/Cargo.toml
+++ b/rust_icu_ucal/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucal"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_uchar/Cargo.toml
+++ b/rust_icu_uchar/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uchar"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucnv/Cargo.toml
+++ b/rust_icu_ucnv/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucnv"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ucol/Cargo.toml
+++ b/rust_icu_ucol/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucol"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ucsdet/Cargo.toml
+++ b/rust_icu_ucsdet/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ucsdet"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -16,9 +16,9 @@ ucsdet.h
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.7.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udat/Cargo.toml
+++ b/rust_icu_udat/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_udat"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,19 +19,19 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "5.6.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.6.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "5.7.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.7.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"
 
 [build-dependencies]
 anyhow = "1.0"
-rust_icu_release = { path = "../rust_icu_release", version = "5.6.0" }
+rust_icu_release = { path = "../rust_icu_release", version = "5.7.0" }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_udata/Cargo.toml
+++ b/rust_icu_udata/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_udata"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uenum/Cargo.toml
+++ b/rust_icu_uenum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uenum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_uformattable/Cargo.toml
+++ b/rust_icu_uformattable/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_uformattable"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ulistformatter/Cargo.toml
+++ b/rust_icu_ulistformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ulistformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,9 +17,9 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_uloc/Cargo.toml
+++ b/rust_icu_uloc/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust_icu_uloc"
 build = "build.rs"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,10 +18,10 @@ uloc.h
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]
@@ -57,7 +57,7 @@ icu_version_in_env = [
 
 [build-dependencies]
 anyhow = "1.0"
-rust_icu_release = { path = "../rust_icu_release", version = "5.6.0" }
+rust_icu_release = { path = "../rust_icu_release", version = "5.7.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust_icu_umsg/Cargo.toml
+++ b/rust_icu_umsg/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_umsg"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -19,14 +19,14 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 thiserror = "1.0.9"
 
 [dev-dependencies]
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "5.6.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "5.7.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_unorm2/Cargo.toml
+++ b/rust_icu_unorm2/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unorm2"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,12 +18,12 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_ucal = { path = "../rust_icu_ucal", version = "5.6.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.6.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_ucal = { path = "../rust_icu_ucal", version = "5.7.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.7.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 
 [dev-dependencies]
 regex = "1"

--- a/rust_icu_unum/Cargo.toml
+++ b/rust_icu_unum/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unum"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,11 +17,11 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "5.6.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "5.7.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_unumberformatter/Cargo.toml
+++ b/rust_icu_unumberformatter/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_unumberformatter"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -18,12 +18,12 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "5.6.0", default-features = false }
-rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.6.0", default-features = false }
-rust_icu_unum = { path = "../rust_icu_unum", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uformattable = { path = "../rust_icu_uformattable", version = "5.7.0", default-features = false }
+rust_icu_uloc = { path = "../rust_icu_uloc", version = "5.7.0", default-features = false }
+rust_icu_unum = { path = "../rust_icu_unum", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"

--- a/rust_icu_upluralrules/Cargo.toml
+++ b/rust_icu_upluralrules/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_upluralrules"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 keywords = ["icu", "unicode", "i18n", "l10n"]
 
 description = """
@@ -17,10 +17,10 @@ Native bindings to the ICU4C library from Unicode.
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 anyhow = "1.0.25"
 
 [dev-dependencies]

--- a/rust_icu_ures/Cargo.toml
+++ b/rust_icu_ures/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ures"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,9 +18,9 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 anyhow = "1"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys    = { path = "../rust_icu_sys",    version = "5.6.0", default-features = false }
-rust_icu_uenum  = { path = "../rust_icu_uenum",  version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys    = { path = "../rust_icu_sys",    version = "5.7.0", default-features = false }
+rust_icu_uenum  = { path = "../rust_icu_uenum",  version = "5.7.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_ures/README.md
+++ b/rust_icu_ures/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/rust_icu_ustring/Cargo.toml
+++ b/rust_icu_ustring/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "rust_icu_ustring"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,8 +18,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 [dependencies]
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utext/Cargo.toml
+++ b/rust_icu_utext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "rust_icu_utext"
-version = "5.6.0"
+version = "5.7.0"
 authors = ["Google Inc."]
 license = "Apache-2.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ keywords = ["icu", "unicode", "i18n", "l10n"]
 
 [dependencies]
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
 
 # See the feature description in ../rust_icu_sys/Cargo.toml for details.
 [features]

--- a/rust_icu_utrans/Cargo.toml
+++ b/rust_icu_utrans/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "rust_icu_utrans"
 readme = "README.md"
 repository = "https://github.com/google/rust_icu"
-version = "5.6.0"
+version = "5.7.0"
 
 description = """
 Native bindings to the ICU4C library from Unicode.
@@ -18,10 +18,10 @@ Native bindings to the ICU4C library from Unicode.
 anyhow = "1.0.25"
 log = "0.4.6"
 paste = "1.0"
-rust_icu_common = { path = "../rust_icu_common", version = "5.6.0", default-features = false }
-rust_icu_sys = { path = "../rust_icu_sys", version = "5.6.0", default-features = false }
-rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.6.0", default-features = false }
-rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.6.0", default-features = false }
+rust_icu_common = { path = "../rust_icu_common", version = "5.7.0", default-features = false }
+rust_icu_sys = { path = "../rust_icu_sys", version = "5.7.0", default-features = false }
+rust_icu_uenum = { path = "../rust_icu_uenum", version = "5.7.0", default-features = false }
+rust_icu_ustring = { path = "../rust_icu_ustring", version = "5.7.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.25"


### PR DESCRIPTION
Summary of changes since 5.6.0:

- feat(ures): add rust_icu_ures safe bindings for ResourceBundle C API
- feat(utext): add is_writable() and improve tests
- fix(sys): blocklist va_list to fix platform-dependent bindgen, fix Windows/mingw builds
- fix(utext): fix use-after-free and dangling pointer issues
- fix(ucnv): correct pivot buffer target pointer
- fix(security): fix unwrap() panics on C string conversion
- fix: various compiler warnings and lint issues
- build: CI updates, macOS support, buildenv tests, limit ICU build concurrency
- docs: add CONTRIBUTING.md, update crate docs

This commit was created by an automated coding assistant, with human supervision.

TAG=agy
CONV=5046784d-730f-4998-8f74-a35e4be43605