### PR TITLE
build: format bazel files with buildifier

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,12 +4,11 @@ buildifier(
     name = "buildifier",
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "bazel-main",
-    deps = [],
     visibility = ["//visibility:public"],
+    deps = [],
 )

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,9 +1,37 @@
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish_all",
-    deps = ["//rust_icu_common:publish", "//rust_icu_ures:publish", "//rust_icu_uenum:publish", "//ecma402_traits:publish", "//rust_icu_umsg:publish", "//rust_icu_sys:publish", "//rust_icu_unorm2:publish", "//rust_icu_unum:publish", "//rust_icu_ustring:publish", "//rust_icu_udata:publish", "//rust_icu:publish", "//rust_icu_utrans:publish", "//rust_icu_unumberformatter:publish", "//rust_icu_udat:publish", "//rust_icu_ucal:publish", "//rust_icu_uchar:publish", "//rust_icu_ecma402:publish", "//rust_icu_uformattable:publish", "//rust_icu_ulistformatter:publish", "//rust_icu_ucol:publish", "//rust_icu_ucnv:publish", "//rust_icu_release:publish", "//rust_icu_uloc:publish", "//rust_icu_ucsdet:publish", "//rust_icu_intl:publish", "//rust_icu_upluralrules:publish", "//rust_icu_utext:publish", "//rust_icu_ubrk:publish"],
+    deps = [
+        "//ecma402_traits:publish",
+        "//rust_icu:publish",
+        "//rust_icu_common:publish",
+        "//rust_icu_ecma402:publish",
+        "//rust_icu_intl:publish",
+        "//rust_icu_release:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_ubrk:publish",
+        "//rust_icu_ucal:publish",
+        "//rust_icu_uchar:publish",
+        "//rust_icu_ucnv:publish",
+        "//rust_icu_ucol:publish",
+        "//rust_icu_ucsdet:publish",
+        "//rust_icu_udat:publish",
+        "//rust_icu_udata:publish",
+        "//rust_icu_uenum:publish",
+        "//rust_icu_uformattable:publish",
+        "//rust_icu_ulistformatter:publish",
+        "//rust_icu_uloc:publish",
+        "//rust_icu_umsg:publish",
+        "//rust_icu_unorm2:publish",
+        "//rust_icu_unum:publish",
+        "//rust_icu_unumberformatter:publish",
+        "//rust_icu_upluralrules:publish",
+        "//rust_icu_ures:publish",
+        "//rust_icu_ustring:publish",
+        "//rust_icu_utext:publish",
+        "//rust_icu_utrans:publish",
+    ],
 )
 
 label_flag(

--- a/bazel/publish.bzl
+++ b/bazel/publish.bzl
@@ -4,35 +4,35 @@ def _cargo_publish_impl(ctx):
     transitive_crates = []
     for dep in ctx.attr.deps:
         transitive_crates.append(dep[PublishInfo].crates)
-    
+
     my_crates = depset(
         direct = [ctx.attr.crate_dir] if ctx.attr.crate_dir else [],
         transitive = transitive_crates,
-        order = "postorder" 
+        order = "postorder",
     )
-    
+
     script = ctx.actions.declare_file(ctx.label.name + ".sh")
     lines = ["#!/bin/bash", "set -e"]
     lines.append("echo 'Starting topological publish...'")
-    
+
     crate_list = my_crates.to_list()
-    
+
     for crate in crate_list:
         lines.append("echo '==================================='")
         lines.append("echo 'Publishing {}'".format(crate))
         lines.append("cd $BUILD_WORKSPACE_DIRECTORY/{}".format(crate))
         lines.append("cargo publish || echo 'Publish failed, possibly already published'")
         lines.append("sleep 30")
-    
+
     ctx.actions.write(
         output = script,
         content = "\n".join(lines),
         is_executable = True,
     )
-    
+
     return [
         DefaultInfo(executable = script, runfiles = ctx.runfiles()),
-        PublishInfo(crates = my_crates)
+        PublishInfo(crates = my_crates),
     ]
 
 cargo_publish = rule(

--- a/ecma402_traits/BUILD.bazel
+++ b/ecma402_traits/BUILD.bazel
@@ -3,34 +3,39 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "ecma402_traits",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+    ],
 )
 
 rust_test(
-
     name = "ecma402_traits_test",
     crate = ":ecma402_traits",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
-
 
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "ecma402_traits",
-    deps = [],
     visibility = ["//visibility:public"],
+    deps = [],
 )

--- a/rust_icu/BUILD.bazel
+++ b/rust_icu/BUILD.bazel
@@ -1,11 +1,26 @@
-
-
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu",
-    deps = ["//rust_icu_ulistformatter:publish", "//rust_icu_ures:publish", "//rust_icu_ubrk:publish", "//rust_icu_umsg:publish", "//rust_icu_common:publish", "//rust_icu_utext:publish", "//rust_icu_uenum:publish", "//rust_icu_uloc:publish", "//rust_icu_sys:publish", "//rust_icu_ucol:publish", "//rust_icu_utrans:publish", "//rust_icu_udat:publish", "//rust_icu_unorm2:publish", "//rust_icu_ucsdet:publish", "//rust_icu_ustring:publish", "//rust_icu_ucal:publish", "//rust_icu_udata:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_ubrk:publish",
+        "//rust_icu_ucal:publish",
+        "//rust_icu_ucol:publish",
+        "//rust_icu_ucsdet:publish",
+        "//rust_icu_udat:publish",
+        "//rust_icu_udata:publish",
+        "//rust_icu_uenum:publish",
+        "//rust_icu_ulistformatter:publish",
+        "//rust_icu_uloc:publish",
+        "//rust_icu_umsg:publish",
+        "//rust_icu_unorm2:publish",
+        "//rust_icu_ures:publish",
+        "//rust_icu_ustring:publish",
+        "//rust_icu_utext:publish",
+        "//rust_icu_utrans:publish",
+    ],
 )

--- a/rust_icu_common/BUILD.bazel
+++ b/rust_icu_common/BUILD.bazel
@@ -2,35 +2,46 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
     name = "rust_icu_common",
-    srcs = glob(["src/**/*.rs", "tests/**/*.rs"]),
+    srcs = glob([
+        "src/**/*.rs",
+        "tests/**/*.rs",
+    ]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:anyhow", "@crates//:thiserror", "//rust_icu_sys:rust_icu_sys"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_sys",
+        "@crates//:anyhow",
+        "@crates//:thiserror",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_common_test",
     crate = ":rust_icu_common",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_common",
-    deps = ["//rust_icu_sys:publish"],
     visibility = ["//visibility:public"],
+    deps = ["//rust_icu_sys:publish"],
 )

--- a/rust_icu_ecma402/BUILD.bazel
+++ b/rust_icu_ecma402/BUILD.bazel
@@ -3,41 +3,70 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_ecma402",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
-    
     },
     rustc_flags = ["-Clink-arg=-Wl,--whole-archive"],
-    deps = [
-        "@crates//:anyhow", "//ecma402_traits:ecma402_traits", "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_udat:rust_icu_udat", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uloc:rust_icu_uloc", "//rust_icu_ustring:rust_icu_ustring", "//rust_icu_ulistformatter:rust_icu_ulistformatter", "//rust_icu_upluralrules:rust_icu_upluralrules", "//rust_icu_unum:rust_icu_unum", "//rust_icu_unumberformatter:rust_icu_unumberformatter"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//ecma402_traits",
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_udat",
+        "//rust_icu_ulistformatter",
+        "//rust_icu_uloc",
+        "//rust_icu_unum",
+        "//rust_icu_unumberformatter",
+        "//rust_icu_upluralrules",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_ecma402_test",
     crate = ":rust_icu_ecma402",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
-    
     },
     rustc_flags = ["-Clink-arg=-Wl,--whole-archive"],
-    deps = ["@crates//:anyhow", "@crates//:regex"],
+    deps = [
+        "@crates//:anyhow",
+        "@crates//:regex",
+    ],
 )
-
 
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_ecma402",
-    deps = ["//rust_icu_ulistformatter:publish", "//rust_icu_common:publish", "//rust_icu_unumberformatter:publish", "//rust_icu_uloc:publish", "//rust_icu_sys:publish", "//rust_icu_unum:publish", "//ecma402_traits:publish", "//rust_icu_upluralrules:publish", "//rust_icu_ustring:publish", "//rust_icu_udat:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//ecma402_traits:publish",
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_udat:publish",
+        "//rust_icu_ulistformatter:publish",
+        "//rust_icu_uloc:publish",
+        "//rust_icu_unum:publish",
+        "//rust_icu_unumberformatter:publish",
+        "//rust_icu_upluralrules:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_intl/BUILD.bazel
+++ b/rust_icu_intl/BUILD.bazel
@@ -3,37 +3,56 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_intl",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:anyhow", "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uloc:rust_icu_uloc", "//rust_icu_umsg:rust_icu_umsg", "//rust_icu_ustring:rust_icu_ustring", "@crates//:thiserror"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uloc",
+        "//rust_icu_umsg",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+        "@crates//:thiserror",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_intl_test",
     crate = ":rust_icu_intl",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_intl",
-    deps = ["//rust_icu_umsg:publish", "//rust_icu_common:publish", "//rust_icu_uloc:publish", "//rust_icu_sys:publish", "//rust_icu_ustring:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uloc:publish",
+        "//rust_icu_umsg:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_release/BUILD.bazel
+++ b/rust_icu_release/BUILD.bazel
@@ -3,16 +3,15 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 rust_library(
     name = "rust_icu_release",
     srcs = glob(["src/**/*.rs"]),
-    deps = ["@crates//:anyhow"],
     visibility = ["//visibility:public"],
+    deps = ["@crates//:anyhow"],
 )
-
 
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_release",
-    deps = [],
     visibility = ["//visibility:public"],
+    deps = [],
 )

--- a/rust_icu_sys/BUILD.bazel
+++ b/rust_icu_sys/BUILD.bazel
@@ -5,40 +5,59 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
-    crate_features = ["renaming", "static", "icu_version_in_env"],
-    deps = [
-        "@crates//:anyhow",
-        "@crates//:lazy_static",
-        "//rust_icu_release:rust_icu_release",
+    build_script_env = {
+        "BAZEL": "1",
+    },
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
     ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    build_script_env = {
-        "BAZEL": "1",
-    },
+    deps = [
+        "//rust_icu_release",
+        "@crates//:anyhow",
+        "@crates//:lazy_static",
+    ],
 )
 
 rust_library(
     name = "rust_icu_sys",
-    srcs = glob(["src/**/*.rs", "tests/**/*.rs", "bindgen/**/*.rs"]),
+    srcs = glob([
+        "src/**/*.rs",
+        "tests/**/*.rs",
+        "bindgen/**/*.rs",
+    ]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
+    link_deps = [
+        "//bazel:icu_backend",
+        ":icudata_alwayslink",
+    ],
     proc_macro_deps = ["@crates//:paste"],
-    crate_features = ["renaming", "static", "icu_version_in_env"],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:libc",
-        ":build_script",
-    ],
-    link_deps = ["//bazel:icu_backend", ":icudata_alwayslink"],
     visibility = ["//visibility:public"],
+    deps = [
+        ":build_script",
+        "@crates//:libc",
+    ],
 )
 
 rust_test(
     name = "rust_icu_sys_test",
     crate = ":rust_icu_sys",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
@@ -56,12 +75,11 @@ cc_library(
     alwayslink = True,
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_sys",
-    deps = ["//rust_icu_release:publish"],
     visibility = ["//visibility:public"],
+    deps = ["//rust_icu_release:publish"],
 )

--- a/rust_icu_ubrk/BUILD.bazel
+++ b/rust_icu_ubrk/BUILD.bazel
@@ -3,37 +3,52 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_ubrk",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uloc:rust_icu_uloc", "//rust_icu_ustring:rust_icu_ustring"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uloc",
+        "//rust_icu_ustring",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_ubrk_test",
     crate = ":rust_icu_ubrk",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = ["@crates//:anyhow"],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_ubrk",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_ustring:publish", "//rust_icu_common:publish", "//rust_icu_uloc:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uloc:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_ucal/BUILD.bazel
+++ b/rust_icu_ucal/BUILD.bazel
@@ -3,37 +3,55 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_ucal",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
+    rustc_env = {
+        "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
+    },
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uenum",
+        "//rust_icu_ustring",
+        "@crates//:log",
+    ],
+)
+
+rust_test(
+    name = "rust_icu_ucal_test",
+    crate = ":rust_icu_ucal",
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uenum:rust_icu_uenum", "//rust_icu_ustring:rust_icu_ustring"
+        "@crates//:anyhow",
+        "@crates//:regex",
     ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
-    visibility = ["//visibility:public"],
 )
-
-rust_test(
-
-    name = "rust_icu_ucal_test",
-    crate = ":rust_icu_ucal",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
-    rustc_env = {
-        "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
-    },
-    deps = ["@crates//:regex", "@crates//:anyhow"],
-)
-
 
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_ucal",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_ustring:publish", "//rust_icu_common:publish", "//rust_icu_uenum:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uenum:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_uchar/BUILD.bazel
+++ b/rust_icu_uchar/BUILD.bazel
@@ -3,37 +3,48 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_uchar",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_uchar_test",
     crate = ":rust_icu_uchar",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_uchar",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_common:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+    ],
 )

--- a/rust_icu_ucnv/BUILD.bazel
+++ b/rust_icu_ucnv/BUILD.bazel
@@ -3,37 +3,48 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_ucnv",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_ucnv_test",
     crate = ":rust_icu_ucnv",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_ucnv",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_common:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+    ],
 )

--- a/rust_icu_ucol/BUILD.bazel
+++ b/rust_icu_ucol/BUILD.bazel
@@ -3,37 +3,53 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_ucol",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uenum:rust_icu_uenum", "//rust_icu_ustring:rust_icu_ustring", "@crates//:anyhow"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uenum",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_ucol_test",
     crate = ":rust_icu_ucol",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = ["@crates//:anyhow"],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_ucol",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_ustring:publish", "//rust_icu_common:publish", "//rust_icu_uenum:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uenum:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_ucsdet/BUILD.bazel
+++ b/rust_icu_ucsdet/BUILD.bazel
@@ -3,34 +3,46 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_ucsdet",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uenum:rust_icu_uenum"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uenum",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_ucsdet_test",
     crate = ":rust_icu_ucsdet",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_ucsdet",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_common:publish", "//rust_icu_uenum:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uenum:publish",
+    ],
 )

--- a/rust_icu_udat/BUILD.bazel
+++ b/rust_icu_udat/BUILD.bazel
@@ -3,37 +3,57 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_udat",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_ucal:rust_icu_ucal", "//rust_icu_uenum:rust_icu_uenum", "//rust_icu_uloc:rust_icu_uloc", "//rust_icu_ustring:rust_icu_ustring"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_ucal",
+        "//rust_icu_uenum",
+        "//rust_icu_uloc",
+        "//rust_icu_ustring",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_udat_test",
     crate = ":rust_icu_udat",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = ["@crates//:regex"],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_udat",
-    deps = ["//rust_icu_common:publish", "//rust_icu_uenum:publish", "//rust_icu_uloc:publish", "//rust_icu_sys:publish", "//rust_icu_release:publish", "//rust_icu_ustring:publish", "//rust_icu_ucal:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_release:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_ucal:publish",
+        "//rust_icu_uenum:publish",
+        "//rust_icu_uloc:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_udata/BUILD.bazel
+++ b/rust_icu_udata/BUILD.bazel
@@ -3,37 +3,48 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_udata",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_udata_test",
     crate = ":rust_icu_udata",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_udata",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_common:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+    ],
 )

--- a/rust_icu_uenum/BUILD.bazel
+++ b/rust_icu_uenum/BUILD.bazel
@@ -3,37 +3,47 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_uenum",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "//rust_icu_sys:rust_icu_sys", "//rust_icu_common:rust_icu_common"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_uenum_test",
     crate = ":rust_icu_uenum",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_uenum",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_common:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+    ],
 )

--- a/rust_icu_uformattable/BUILD.bazel
+++ b/rust_icu_uformattable/BUILD.bazel
@@ -3,37 +3,51 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_uformattable",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_ustring:rust_icu_ustring", "@crates//:anyhow"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_uformattable_test",
     crate = ":rust_icu_uformattable",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = ["@crates//:anyhow"],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_uformattable",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_ustring:publish", "//rust_icu_common:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_ulistformatter/BUILD.bazel
+++ b/rust_icu_ulistformatter/BUILD.bazel
@@ -3,37 +3,51 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_ulistformatter",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_ustring:rust_icu_ustring", "@crates//:anyhow"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_ulistformatter_test",
     crate = ":rust_icu_ulistformatter",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = ["@crates//:anyhow"],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_ulistformatter",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_ustring:publish", "//rust_icu_common:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_uloc/BUILD.bazel
+++ b/rust_icu_uloc/BUILD.bazel
@@ -3,37 +3,54 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_uloc",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uenum:rust_icu_uenum", "//rust_icu_ustring:rust_icu_ustring", "@crates//:anyhow"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uenum",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_uloc_test",
     crate = ":rust_icu_uloc",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_uloc",
-    deps = ["//rust_icu_common:publish", "//rust_icu_uenum:publish", "//rust_icu_sys:publish", "//rust_icu_release:publish", "//rust_icu_ustring:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_release:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uenum:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_umsg/BUILD.bazel
+++ b/rust_icu_umsg/BUILD.bazel
@@ -3,37 +3,55 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_umsg",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:anyhow", "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uloc:rust_icu_uloc", "//rust_icu_ustring:rust_icu_ustring", "@crates//:thiserror"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uloc",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+        "@crates//:thiserror",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_umsg_test",
     crate = ":rust_icu_umsg",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = ["//rust_icu_ucal:rust_icu_ucal"],
+    deps = ["//rust_icu_ucal"],
 )
-
 
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_umsg",
-    deps = ["//rust_icu_common:publish", "//rust_icu_uloc:publish", "//rust_icu_sys:publish", "//rust_icu_ustring:publish", "//rust_icu_ucal:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_ucal:publish",
+        "//rust_icu_uloc:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_unorm2/BUILD.bazel
+++ b/rust_icu_unorm2/BUILD.bazel
@@ -3,37 +3,56 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_unorm2",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_ucal:rust_icu_ucal", "//rust_icu_uenum:rust_icu_uenum", "//rust_icu_uloc:rust_icu_uloc", "//rust_icu_ustring:rust_icu_ustring"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_ucal",
+        "//rust_icu_uenum",
+        "//rust_icu_uloc",
+        "//rust_icu_ustring",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_unorm2_test",
     crate = ":rust_icu_unorm2",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = ["@crates//:regex"],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_unorm2",
-    deps = ["//rust_icu_common:publish", "//rust_icu_uenum:publish", "//rust_icu_uloc:publish", "//rust_icu_sys:publish", "//rust_icu_ustring:publish", "//rust_icu_ucal:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_ucal:publish",
+        "//rust_icu_uenum:publish",
+        "//rust_icu_uloc:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_unum/BUILD.bazel
+++ b/rust_icu_unum/BUILD.bazel
@@ -3,37 +3,55 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_unum",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uformattable:rust_icu_uformattable", "//rust_icu_uloc:rust_icu_uloc", "//rust_icu_ustring:rust_icu_ustring", "@crates//:anyhow"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uformattable",
+        "//rust_icu_uloc",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_unum_test",
     crate = ":rust_icu_unum",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = ["@crates//:anyhow"],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_unum",
-    deps = ["//rust_icu_common:publish", "//rust_icu_uformattable:publish", "//rust_icu_uloc:publish", "//rust_icu_sys:publish", "//rust_icu_ustring:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uformattable:publish",
+        "//rust_icu_uloc:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_unumberformatter/BUILD.bazel
+++ b/rust_icu_unumberformatter/BUILD.bazel
@@ -3,37 +3,57 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_unumberformatter",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:anyhow", "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uformattable:rust_icu_uformattable", "//rust_icu_uloc:rust_icu_uloc", "//rust_icu_unum:rust_icu_unum", "//rust_icu_ustring:rust_icu_ustring"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uformattable",
+        "//rust_icu_uloc",
+        "//rust_icu_unum",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_unumberformatter_test",
     crate = ":rust_icu_unumberformatter",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = ["@crates//:anyhow"],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_unumberformatter",
-    deps = ["//rust_icu_common:publish", "//rust_icu_uformattable:publish", "//rust_icu_uloc:publish", "//rust_icu_sys:publish", "//rust_icu_unum:publish", "//rust_icu_ustring:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uformattable:publish",
+        "//rust_icu_uloc:publish",
+        "//rust_icu_unum:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_upluralrules/BUILD.bazel
+++ b/rust_icu_upluralrules/BUILD.bazel
@@ -3,37 +3,53 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_upluralrules",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_uenum:rust_icu_uenum", "//rust_icu_sys:rust_icu_sys", "//rust_icu_ustring:rust_icu_ustring", "@crates//:anyhow"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uenum",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_upluralrules_test",
     crate = ":rust_icu_upluralrules",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = ["@crates//:anyhow"],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_upluralrules",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_ustring:publish", "//rust_icu_common:publish", "//rust_icu_uenum:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uenum:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )

--- a/rust_icu_ures/BUILD.bazel
+++ b/rust_icu_ures/BUILD.bazel
@@ -3,25 +3,36 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_ures",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:anyhow", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uenum:rust_icu_uenum"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uenum",
+        "@crates//:anyhow",
+    ],
 )
 
 rust_test(
     name = "rust_icu_ures_test",
-    data = glob(["testdata/*.res"]),
     crate = ":rust_icu_ures",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
+    data = glob(["testdata/*.res"]),
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
         "TEST_DATA_DIR": "rust_icu_ures/testdata",
@@ -29,12 +40,15 @@ rust_test(
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_ures",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_common:publish", "//rust_icu_uenum:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uenum:publish",
+    ],
 )

--- a/rust_icu_ustring/BUILD.bazel
+++ b/rust_icu_ustring/BUILD.bazel
@@ -3,37 +3,48 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_ustring",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_ustring_test",
     crate = ":rust_icu_ustring",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_ustring",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_common:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+    ],
 )

--- a/rust_icu_utext/BUILD.bazel
+++ b/rust_icu_utext/BUILD.bazel
@@ -3,37 +3,47 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_utext",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_utext_test",
     crate = ":rust_icu_utext",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = [],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_utext",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_common:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+    ],
 )

--- a/rust_icu_utrans/BUILD.bazel
+++ b/rust_icu_utrans/BUILD.bazel
@@ -3,37 +3,53 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "rust_icu_utrans",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     edition = "2021",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
-    deps = [
-        "@crates//:anyhow", "@crates//:log", "//rust_icu_common:rust_icu_common", "//rust_icu_sys:rust_icu_sys", "//rust_icu_uenum:rust_icu_uenum", "//rust_icu_ustring:rust_icu_ustring"
-    ],
-    proc_macro_deps = [
-        "@crates//:paste"
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common",
+        "//rust_icu_sys",
+        "//rust_icu_uenum",
+        "//rust_icu_ustring",
+        "@crates//:anyhow",
+        "@crates//:log",
+    ],
 )
 
 rust_test(
-
     name = "rust_icu_utrans_test",
     crate = ":rust_icu_utrans",
-    crate_features = ["renaming", "static", "icu_version_in_env"],
+    crate_features = [
+        "renaming",
+        "static",
+        "icu_version_in_env",
+    ],
     rustc_env = {
         "RUST_ICU_MAJOR_VERSION_NUMBER": "74",
     },
     deps = ["@crates//:anyhow"],
 )
 
-
 load("//bazel:publish.bzl", "cargo_publish")
 
 cargo_publish(
     name = "publish",
     crate_dir = "rust_icu_utrans",
-    deps = ["//rust_icu_sys:publish", "//rust_icu_ustring:publish", "//rust_icu_common:publish", "//rust_icu_uenum:publish"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//rust_icu_common:publish",
+        "//rust_icu_sys:publish",
+        "//rust_icu_uenum:publish",
+        "//rust_icu_ustring:publish",
+    ],
 )


### PR DESCRIPTION
Ran buildifier -r . across the entire Bazel workspace to ensure formatting consistency.