### PR TITLE
ci: satisfy zizmor policy in test.yml and buildenv.yml

### DIFF
--- a/.github/workflows/buildenv.yml
+++ b/.github/workflows/buildenv.yml
@@ -18,10 +18,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# The workflow reads the repository and runs the tests in Docker. It writes
+# nothing back, so the token needs no more than read access.
+permissions:
+  contents: read
+
 jobs:
   test-buildenv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - name: Build and test buildenv images
         run: make -C build VERSION=test test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+# The workflow reads the repository and runs the tests in Docker. It writes
+# nothing back, so the token needs no more than read access.
+permissions:
+  contents: read
+
 jobs:
   test-default-features:
     runs-on: ubuntu-latest
@@ -17,7 +22,9 @@ jobs:
       matrix:
         icu_version: [74, 76, 77]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - name: 'Test ICU version ${{ matrix.icu_version }}'
         run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version}} docker-test'
   test-with-features:
@@ -29,13 +36,17 @@ jobs:
           - "renaming,icu_version_in_env"
           - "renaming,icu_config,use-bindgen"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - name: 'Test ICU version ${{ matrix.icu_version }}'
         run: 'make DOCKER_TEST_ENV=rust_icu_testenv-${{ matrix.icu_version }} RUST_ICU_MAJOR_VERSION_NUMBER=${{ matrix.icu_version }} DOCKER_TEST_CARGO_TEST_ARGS="--no-default-features --features ${{ matrix.feature_set }}" docker-test'
   test-bindgen:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - name: 'Test static-bindgen'
         run: 'make static-bindgen'
   test-static-linking:
@@ -44,7 +55,9 @@ jobs:
       matrix:
         runs-on: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - if: matrix.runs-on == 'macos-latest'
         run: make macos-test
       - if: matrix.runs-on == 'ubuntu-latest'
@@ -55,7 +68,9 @@ jobs:
       matrix:
         icu_version: [77]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - name: 'Test ICU `main`'
         run: |
           make DOCKER_TEST_ENV=rust_icu_testenv-current RUST_ICU_MAJOR_VERSION_NUMBER=${{matrix.icu_version}} docker-test-current


### PR DESCRIPTION
`test.yml` and `buildenv.yml` are the two workflows on `main`. Neither has
been through the zizmor policy. Together they draw **31 findings: 6 high,
7 medium, 6 low.**

The gate fails at medium severity, so the next change to either file blocks
on findings that have nothing to do with that change. #388 hit exactly this,
one file at a time.

## The three rules, and what each needed

**`unpinned-uses` — high, 6 sites.** The blanket policy wants a commit hash.
All six checkout steps read `actions/checkout@v6`. They now read
`actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6`. The hash
comes from the tag, read through the GitHub API rather than copied.

**`excessive-permissions` — medium, 7 sites.** Neither workflow declared a
token scope, so every job ran with the default. Both now declare
`contents: read` once, at workflow level. The jobs inherit it, and a job
added later inherits it too.

**`artipacked` — low, 6 sites.** `actions/checkout` leaves the token in
`.git/config` unless told otherwise. Each step now sets
`persist-credentials: false`.

Low findings do not fail the gate. They cost one line each here, so the
change clears all three rules rather than the two that block.

## Why removing the credentials is safe

Every job in both files runs a local `make` target: `docker-test`,
`static-bindgen`, `macos-test`, `test`, `docker-test-current`, and
`make -C build test`. None pushes. None calls git over the network. No job
needs a writable or a persisted token.

## Verification

Run against zizmor 1.29.0 with the same `regular` persona the CI job uses:

```
before: 31 findings (12 suppressed): 0 informational, 6 low, 7 medium, 6 high
after:  No findings to report. Good job! (11 suppressed)
```

No test or build logic changes. The only edits are the pin, the permissions
block and `persist-credentials`.
