### PR TITLE
fix(umsg): retry the format call when the output does not fit

### DIFF
--- a/rust_icu_umsg/src/lib.rs
+++ b/rust_icu_umsg/src/lib.rs
@@ -51,7 +51,7 @@
 //! # }
 //!
 //! fn testfn() -> Result<(), common::Error> {
-//! #   let _ = TzSave(ucal::get_default_time_zone()?);
+//! #   let _tz = TzSave(ucal::get_default_time_zone()?);
 //! #   ucal::set_default_time_zone("Europe/Amsterdam")?;
 //!     let loc = uloc::ULoc::try_from("en-US-u-tz-uslax")?;
 //!     let msg = ustring::UChar::try_from(
@@ -336,7 +336,7 @@ impl UMessageFormat {
 /// # }
 ///
 /// fn testfn() -> Result<(), common::Error> {
-/// # let _ = TzSave(ucal::get_default_time_zone()?);
+/// # let _tz = TzSave(ucal::get_default_time_zone()?);
 /// # ucal::set_default_time_zone("Europe/Amsterdam")?;
 ///   let loc = uloc::ULoc::try_from("en-US")?;
 ///   let msg = ustring::UChar::try_from(
@@ -419,11 +419,20 @@ pub unsafe fn format_args(
 
     let total_size =
         args.format(fmt.rep.rep, result.as_mut_c_ptr(), CAP as i32, &mut status) as usize;
-    common::Error::ok_or_warning(status)?;
 
-    result.resize(total_size);
-
-    if total_size > CAP {
+    // ICU is inconsistent about an output that does not fit: some paths raise
+    // U_BUFFER_OVERFLOW_ERROR, others truncate silently and return the length
+    // they wanted. Check both, as rust_icu_ulistformatter and
+    // common::buffered_string_method_with_retry do.
+    if status == sys::UErrorCode::U_BUFFER_OVERFLOW_ERROR
+        || (common::Error::is_ok(status) && total_size > CAP)
+    {
+        // The first call only measured the output. Clear the status before
+        // calling again: an ICU entry point does no work when the status it
+        // receives already holds an error, so a retry that reuses a failed
+        // status is a silent no-op.
+        status = common::Error::OK_CODE;
+        result.resize(total_size);
         args.format(
             fmt.rep.rep,
             result.as_mut_c_ptr(),
@@ -431,6 +440,9 @@ pub unsafe fn format_args(
             &mut status,
         );
         common::Error::ok_or_warning(status)?;
+    } else {
+        common::Error::ok_or_warning(status)?;
+        result.resize(total_size);
     }
     String::try_from(&result)
 }
@@ -568,14 +580,14 @@ mod tests {
 
     #[test]
     fn tzsave() -> Result<(), common::Error> {
-        let _ = TzSave(ucal::get_default_time_zone()?);
+        let _tz = TzSave(ucal::get_default_time_zone()?);
         ucal::set_default_time_zone("Europe/Amsterdam")?;
         Ok(())
     }
 
     #[test]
     fn basic() -> Result<(), common::Error> {
-        let _ = TzSave(ucal::get_default_time_zone()?);
+        let _tz = TzSave(ucal::get_default_time_zone()?);
         ucal::set_default_time_zone("Europe/Amsterdam")?;
 
         let loc = uloc::ULoc::try_from("en-US")?;
@@ -607,6 +619,31 @@ mod tests {
         Ok(())
     }
 
+    /// A formatted result longer than the initial buffer must still format.
+    ///
+    /// ICU raises U_BUFFER_OVERFLOW_ERROR when the output does not fit, and the
+    /// formatter has to grow the buffer and call again. Regression test for
+    /// https://github.com/google/rust_icu/issues/390.
+    #[test]
+    fn format_longer_than_initial_buffer() -> Result<(), common::Error> {
+        let loc = uloc::ULoc::try_from("en-US")?;
+        let msg = ustring::UChar::try_from("{0}")?;
+        let fmt = crate::UMessageFormat::try_from(&msg, &loc)?;
+
+        // The initial buffer inside `format_args` holds 1024 UTF-16 units.
+        let long = "x".repeat(4096);
+        // `umsg_format` is variadic, so a String argument carries no length and
+        // ICU reads it until a NUL. `UChar::try_from` does not add one, so the
+        // argument must be terminated explicitly or ICU reads past its end.
+        let mut arg = ustring::UChar::try_from(long.as_str())?;
+        arg.make_z();
+
+        let result = message_format!(fmt, { arg => String })?;
+        assert_eq!(long.len(), result.len());
+        assert_eq!(long, result);
+        Ok(())
+    }
+
     #[test]
     fn clone() -> Result<(), common::Error> {
         let loc = uloc::ULoc::try_from("en-US-u-tz-uslax")?;
@@ -621,7 +658,7 @@ mod tests {
 
     #[test]
     fn try_format_method() -> Result<(), common::Error> {
-        let _ = TzSave(ucal::get_default_time_zone()?);
+        let _tz = TzSave(ucal::get_default_time_zone()?);
         ucal::set_default_time_zone("Europe/Amsterdam")?;
 
         let loc = uloc::ULoc::try_from("en-US")?;


### PR DESCRIPTION
Fixes #390.

`format_args` sized its buffer at 1024 UTF-16 units and could not recover when
the formatted message needed more.

## Two defects in twelve lines

```rust
let total_size = args.format(.., CAP as i32, &mut status);
common::Error::ok_or_warning(status)?;     // (a)

result.resize(total_size);

if total_size > CAP {                      // (b)
    args.format(.., total_size as i32, &mut status);
    common::Error::ok_or_warning(status)?;
}
```

**Branch (b) was unreachable.** ICU raises `U_BUFFER_OVERFLOW_ERROR` exactly
when the output exceeds the buffer, and `(a)` turns that into an early return
one line above the branch. The caller received `Sys(U_BUFFER_OVERFLOW_ERROR)`
instead of a formatted string. The condition `total_size > CAP` covers only the
silent-truncation case, which is not the case ICU takes here.

**The status was never cleared.** An ICU entry point does no work when the
status it receives already holds an error. Even if control had reached `(b)`,
the retry would have been a no-op and the check after it would have re-raised
the same error.

## The fix

It follows the idiom already in this repository —
`rust_icu_ulistformatter/src/lib.rs:124` and
`common::buffered_string_method_with_retry` in `rust_icu_common/src/lib.rs:209`.
Both treat the explicit overflow error **and** a silently truncated result as
the signal to grow, then clear the status before calling again.

## A deterministic reproduction

The issue reported this as an intermittent CI failure. The new test makes it
deterministic: it formats a 4096 unit argument through the 1024 unit buffer. On
the unmodified code it fails with the same error CI saw:

```
---- tests::format_longer_than_initial_buffer stdout ----
Error: Sys(U_BUFFER_OVERFLOW_ERROR)
```

I re-ran the finished test against the unpatched `format_args` to confirm it
still reproduces the defect.

## A sharp edge the test ran into, worth knowing

The test calls `make_z()` on its argument. That is not decoration.

`umsg_format` is **variadic**, so a `String` argument carries no length and ICU
reads it until a NUL. `UChar::try_from(&str)` allocates `vec![0; dest_length]`,
exactly the string, with no terminator. An argument that is not terminated
makes ICU read past its end.

The first revisions of this pull request got that wrong, and CI caught it: the
formatted length came back as 4097 on one run and 4100 on the next, varying
with whatever followed the buffer in memory. Two intermediate revisions chased
that as if it were an ICU version difference before the real cause turned up.

Note that `tests::basic` and the module documentation both pass a
non-terminated `UChar` as a `String` argument today. They pass because the byte
after the buffer happens to be zero. That is the same class of hazard as #371,
and it is left alone here rather than widened into this change.

## The guard bug is fixed too

The issue noted that `let _ = TzSave(..)` does not do what it looks like.
`let _ = expr` drops the value immediately rather than at the end of scope, so
the guard restored the time zone at once and never ran at the end of the test.
Named bindings now hold the guards. Three tests and two documentation examples
change.

## Verification

Against ICU 74.2:

```
cargo test -p rust_icu_umsg               7 tests, all pass or ignored
cargo check --workspace                   clean
cargo fmt -p rust_icu_umsg -- --check     clean
```

## What this does not fix

The third suggestion in the issue is untouched. The time zone tests still
mutate process-global ICU state while cargo runs them in parallel. That was a
hypothesis about the original intermittency rather than a verified cause, and it
needs a different change. The issue should stay open for it.
