### PR TITLE
ci: use a dedicated token for release-please to resolve CLA checks

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: release
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
Google CLA checker blocks commits from `github-actions[bot]`. Passing a dedicated properly-enrolled robot PAT to release-please ensures it bypasses CLA checks legally. Ensure you add `RELEASE_PLEASE_TOKEN` to the repository secrets prior to merging.