### PR TITLE
build: generate the coverage report without exuberant-ctags

### DIFF
--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -16,7 +16,6 @@ apt-utils \
 clang \
 coreutils \
 curl \
-exuberant-ctags \
 gawk \
 git \
 libclang-dev \

--- a/build/icu_c_functions.awk
+++ b/build/icu_c_functions.awk
@@ -1,0 +1,80 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Prints the name of every function declared in an ICU public C header, one
+# per line, in the order the declarations appear.
+#
+# This replaces "ctags -x --c-kinds=fp", which needed exuberant-ctags: the
+# --c-kinds flag is specific to that implementation, so the report could not
+# be generated with the ctags shipped by many systems.  awk is in POSIX, so
+# nothing extra has to be installed.
+#
+# The extraction relies on how ICU declares its C API rather than on parsing
+# C.  Every public function is introduced by a line holding U_EXPORT2, as in
+#
+#     U_CAPI int32_t U_EXPORT2
+#     umsg_format(const UMessageFormat *fmt, ...);
+#
+# with the name either starting the next line, as above, or trailing on the
+# same line:
+#
+#     U_CAPI int32_t U_EXPORT2 uloc_countAvailable(void);
+#
+# Keying on U_EXPORT2 rather than on U_CAPI also covers the older spellings
+# U_STABLE, U_DRAFT and U_DEPRECATED, which take the same shape.
+
+BEGIN { expect = 0 }
+
+# Continuation lines of a doc comment, e.g. " * @see ucol_clone".  These
+# mention function names but declare nothing.
+/^[ \t]*\*/ { next }
+
+{
+  line = $0
+
+  # A function pointer typedef is spelled with U_CALLCONV, not U_EXPORT2, but
+  # check for "typedef" anyway so a stray one is never taken for a prototype.
+  if (line ~ /U_EXPORT2/ && line !~ /typedef/) {
+    rest = line
+    sub(/^.*U_EXPORT2[ \t]*/, "", rest)
+    if (match(rest, /^[A-Za-z_][A-Za-z0-9_]*[ \t]*\(/)) {
+      name = substr(rest, RSTART, RLENGTH)
+      sub(/[ \t]*\($/, "", name)
+      print name
+      expect = 0
+      next
+    }
+    # The name is on a following line.
+    expect = 1
+    next
+  }
+
+  # ICU also ships a few C++ convenience wrappers around the C API, declared
+  # as "inline <Type>" with the name on the next line.  ctags reported these,
+  # so keep reporting them.
+  if (line ~ /^inline[ \t]/ && line !~ /typedef/) {
+    expect = 1
+    next
+  }
+
+  if (expect) {
+    if (line ~ /^[ \t]*$/) { next }
+    if (match(line, /^[A-Za-z_][A-Za-z0-9_]*[ \t]*\(/)) {
+      name = substr(line, RSTART, RLENGTH)
+      sub(/[ \t]*\($/, "", name)
+      print name
+    }
+    expect = 0
+  }
+}

--- a/build/showprogress.sh
+++ b/build/showprogress.sh
@@ -28,7 +28,21 @@ C_API_HEADER_NAMES=(
   "unorm2"
 )
 
-ICU_INCLUDE_PATH="$(icu-config --cppflags-searchpath | sed -e 's/-I//' | sed -e 's/ //g')"
+# Locate the ICU headers.  icu-config is tried first, since a hand-built ICU
+# installs it and it reports that installation.  It was removed from ICU in
+# favor of pkg-config, though, and distribution packages no longer ship it,
+# so fall back to pkg-config.
+if command -v icu-config >/dev/null 2>&1; then
+  ICU_INCLUDE_PATH="$(icu-config --cppflags-searchpath | sed -e 's/-I//' | sed -e 's/ //g')"
+elif ICU_INCLUDE_PATH="$(pkg-config --variable=includedir icu-uc 2>/dev/null)" \
+    && [[ -n "${ICU_INCLUDE_PATH}" ]]; then
+  :
+else
+  echo "error: cannot find the ICU headers: icu-config is not installed and" \
+       "pkg-config does not know about icu-uc.  Install libicu-dev or the" \
+       "equivalent for your system." >&2
+  exit 1
+fi
 
 # Write a report out as we read the data.
 
@@ -42,7 +56,9 @@ cat <<EOF > "${REPORT_FILE_HEADER}"
 | ------ | ----------- |
 EOF
 
-  cat <<EOF >>"${REPORT_FILE_DETAIL}"
+# Truncate, so that a run following one that died partway through does not
+# append to the leftovers.
+cat <<EOF >"${REPORT_FILE_DETAIL}"
 # Unimplemented functions per header
 
 EOF
@@ -51,8 +67,23 @@ for header_basename in ${C_API_HEADER_NAMES[@]}; do
   : > "${TOP_DIR}/coverage/${header_basename}_all.txt"
   : > "${TOP_DIR}/coverage/${header_basename}_implemented.txt"
   header_fullname="${ICU_INCLUDE_PATH}/unicode/${header_basename}.h"
-  all=$(ctags -x --c-kinds=fp $header_fullname | sed -e 's/ .*$//' \
-    | grep -v U_DEFINE | LC_ALL=C sort -fs | uniq)
+  if [[ ! -r "${header_fullname}" ]]; then
+    echo "error: cannot read ${header_fullname}" >&2
+    exit 1
+  fi
+  # ctags also reported the U_DEFINE_LOCAL_OPEN_POINTER macro invocations as
+  # functions and they had to be filtered out here.  The awk extraction does
+  # not pick them up, so there is nothing left to filter.
+  all=$(awk -f "${DIR}/icu_c_functions.awk" "${header_fullname}" \
+    | LC_ALL=C sort -fs | uniq)
+  # The extraction keys on how ICU spells its declarations, so an empty result
+  # means the header changed shape rather than that it declares nothing.  Say
+  # so instead of reporting 0 / 0 coverage.
+  if [[ -z "${all}" ]]; then
+    echo "error: no functions found in ${header_fullname};" \
+         "${DIR}/icu_c_functions.awk needs updating" >&2
+    exit 1
+  fi
   for fn in ${all}; do
     printf "%s\n" ${fn} >> "${TOP_DIR}/coverage/${header_basename}_all.txt"
   done

--- a/coverage/report.md
+++ b/coverage/report.md
@@ -4,7 +4,7 @@
 | ------ | ----------- |
 | `ubrk.h` | 19 / 23 | 
 | `ucal.h` | 15 / 48 | 
-| `ucol.h` | 8 / 54 | 
+| `ucol.h` | 8 / 51 | 
 | `udat.h` | 5 / 38 | 
 | `udata.h` | 2 / 8 | 
 | `uenum.h` | 3 / 8 | 
@@ -116,9 +116,6 @@
 | | `ucol_setStrength` |
 | | `ucol_strcoll` |
 | | `ucol_strcollUTF8` |
-| `match` | |
-| `operator` | |
-| `Predicate` | |
 | `ucol_clone` | |
 | `ucol_cloneBinary` | |
 | `ucol_close` | |

--- a/coverage/ucol_all.txt
+++ b/coverage/ucol_all.txt
@@ -1,6 +1,3 @@
-match
-operator
-Predicate
 ucol_clone
 ucol_cloneBinary
 ucol_close


### PR DESCRIPTION
Fixes #81

## Root cause

`make cov` runs `build/showprogress.sh`, which extracted the ICU function lists with:

```sh
all=$(ctags -x --c-kinds=fp $header_fullname | ...)
```

`--c-kinds` is specific to exuberant-ctags. Other ctags implementations reject it, and where no ctags is installed the report cannot be generated at all.

While confirming this, I found the script fails even earlier on a current system. Line 31 called `icu-config`, which ICU removed in favor of pkg-config and which distributions no longer ship:

```
$ which ctags icu-config
(neither found)
$ bash build/showprogress.sh
build/showprogress.sh: line 31: icu-config: command not found
```

So the script aborted on its first real command, before reaching the ctags call.

## The change

`build/icu_c_functions.awk` replaces the ctags call. awk is in POSIX, so nothing extra has to be installed.

It keys on how ICU declares its C API rather than on parsing C. Every public function is introduced by a line holding `U_EXPORT2`, with the name either starting the next line:

```c
U_CAPI int32_t U_EXPORT2
umsg_format(const UMessageFormat *fmt, ...);
```

or trailing on the same one:

```c
U_CAPI int32_t U_EXPORT2 uloc_countAvailable(void);
```

Keying on `U_EXPORT2` rather than on `U_CAPI` also covers the older `U_STABLE`, `U_DRAFT` and `U_DEPRECATED` spellings, which take the same shape. Function pointer typedefs use `U_CALLCONV` instead and are skipped. ICU's handful of C++ convenience wrappers, declared `inline <Type>` with the name on the next line, are still reported, because ctags reported them.

The other changes:

* Fall back to pkg-config when `icu-config` is absent. icu-config is still tried first, since a hand-built ICU installs it and it reports that installation, which is what `build/Dockerfile.maint` sets up. Without this the script cannot run at all on a current system, so the ctags fix could not be verified.
* Drop `exuberant-ctags` from `build/Dockerfile.buildenv`. `gawk` is already installed there.
* Truncate the report detail file. It was opened with `>>`, so a run following one that died partway through appended to the leftovers. Easy to hit, since the script currently always dies partway through.
* Error out when a header yields no functions, instead of recording `0 / 0`. The extraction keys on how ICU spells its declarations, so a future change to that should be loud rather than silent.
* Drop the `grep -v U_DEFINE` filter. It existed because ctags reported `U_DEFINE_LOCAL_OPEN_POINTER` macro invocations as functions. The awk extraction does not pick them up (checked on ICU 74 and ICU 77). Keeping it would have been actively harmful: under `set -o pipefail`, `grep -v` exits 1 on empty input, which killed the script silently and made the new "no functions found" check unreachable.

## Verification

Ran on Ubuntu 24.04, ICU 74.2, with neither ctags nor icu-config installed.

**The awk extraction agrees with ctags exactly.** Running the old script and the new script against the same headers produces byte-identical output over all 40 files in `coverage/`:

```
$ diff -r old/coverage new/coverage && echo "IDENTICAL"
IDENTICAL
```

Per header, against both ctags implementations (`exuberant-ctags 5.9`, `universal-ctags 5.9`, which agree with each other on all 18):

```
18 headers, 471 symbols, mismatches: 0
```

Also checked against 10 ICU **77** headers, to confirm the extraction is not overfitted to the ICU version installed here. It matches ctags on 362 symbols, with three differences, all of which are ctags misparses that the awk extraction correctly skips:

```
Predicate   ucol.h:1547  explicit Predicate(const UCollator* ucol) : collator(ucol) {}
match       ucol.h:1594  bool match(std::u16string_view lhs, std::u16string_view rhs) const {
operator () ucol.h:1554  bool operator()(const T& lhs, const U& rhs) const {
```

These are C++ class members in a `U_SHOW_CPLUSPLUS_API` block, not ICU C API. This is why `coverage/report.md` changes in this PR: the checked-in report was generated against a newer ICU and lists `match`, `operator` and `Predicate` as unimplemented ICU functions. `ucol.h` goes from `8 / 54` to `8 / 51`. That is the only content change to the checked-in report; no real function appears or disappears.

Checked with mawk 1.3.4, the default `awk` on Debian and Ubuntu. gawk and busybox awk were not installed here, so I did not run them; the script uses no extension beyond POSIX awk (`match`, `substr`, `sub`, `RSTART`, `RLENGTH`).

Error paths:

```
$ PKG_CONFIG_LIBDIR=/nonexistent PATH=/usr/bin:/bin bash build/showprogress.sh
error: cannot find the ICU headers: icu-config is not installed and pkg-config
does not know about icu-uc.  Install libicu-dev or the equivalent for your system.
exit=1

$ # include path pointing somewhere with no ICU headers
error: cannot read /nonexistent/unicode/ubrk.h

$ # header present but declaring nothing
error: no functions found in .../unicode/ubrk.h; build/icu_c_functions.awk needs updating
```

Workspace check:

```
$ cargo check --workspace
    Checking rust_icu v5.7.0 (/home/user/wt-81/rust_icu)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 30.08s
```

No crate sources changed, so there is no affected crate to run `cargo test` against. Nothing under `.github/workflows/` is touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_011gMb8ygdUYKSHBsAWCixiN)_